### PR TITLE
Fix Ratio metric display on public pages

### DIFF
--- a/src/pages/client/public/DistrictDashboard.tsx
+++ b/src/pages/client/public/DistrictDashboard.tsx
@@ -633,7 +633,7 @@ export function DistrictDashboard() {
                           <div className="border-t border-neutral-200 p-5 bg-neutral-50">
                             {primaryMetric.visualization_type === 'narrative' ? (
                               <NarrativeDisplay config={primaryMetric.visualization_config} />
-                            ) : primaryMetric.visualization_type === 'likert-scale' ? (
+                            ) : (primaryMetric.visualization_type === 'bar' && primaryMetric.visualization_config?.scaleMin) ? (
                               chartData && chartData.length > 0 && (
                                 <LikertScaleChart
                                   data={chartData}
@@ -646,6 +646,20 @@ export function DistrictDashboard() {
                                   showAverage={true}
                                 />
                               )
+                            ) : (primaryMetric.visualization_type === 'number' && primaryMetric.visualization_config?._frontendType === 'ratio') ? (
+                              <div className="p-6 bg-white rounded-lg">
+                                <div className="text-center">
+                                  <div className="text-sm font-medium text-neutral-600 mb-2">{primaryMetric.name}</div>
+                                  <div className="text-3xl font-bold text-neutral-900">
+                                    {primaryMetric.visualization_config?.label || ''}{primaryMetric.visualization_config?.ratioValue || '1.0:1'}
+                                  </div>
+                                  {primaryMetric.visualization_config?.showTarget && primaryMetric.visualization_config?.targetValue && (
+                                    <div className="text-sm text-neutral-500 mt-2">
+                                      Target: {primaryMetric.visualization_config.label}{primaryMetric.visualization_config.targetValue}
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
                             ) : (
                               chartData && chartData.length > 0 && (
                                 <AnnualProgressChart
@@ -740,6 +754,20 @@ export function DistrictDashboard() {
                                               {primarySubMetric.visualization_type === 'narrative' ? (
                                                 <div className="p-5 bg-neutral-50">
                                                   <NarrativeDisplay config={primarySubMetric.visualization_config} />
+                                                </div>
+                                              ) : (primarySubMetric.visualization_type === 'number' && primarySubMetric.visualization_config?._frontendType === 'ratio') ? (
+                                                <div className="p-6 bg-white">
+                                                  <div className="text-center">
+                                                    <div className="text-sm font-medium text-neutral-600 mb-2">{primarySubMetric.name}</div>
+                                                    <div className="text-xl font-bold text-neutral-900 leading-relaxed">
+                                                      {primarySubMetric.visualization_config?.label || ''}{primarySubMetric.visualization_config?.ratioValue || '1.0:1'}
+                                                    </div>
+                                                    {primarySubMetric.visualization_config?.showTarget && primarySubMetric.visualization_config?.targetValue && (
+                                                      <div className="text-sm text-neutral-500 mt-3">
+                                                        Target: {primarySubMetric.visualization_config.label}{primarySubMetric.visualization_config.targetValue}
+                                                      </div>
+                                                    )}
+                                                  </div>
                                                 </div>
                                               ) : primarySubMetric.visualization_type === 'number' ? (
                                                 <div className="p-6 bg-white">

--- a/src/pages/client/public/GoalDetail.tsx
+++ b/src/pages/client/public/GoalDetail.tsx
@@ -149,6 +149,40 @@ export function GoalDetail() {
                       );
                     }
 
+                    // Check if this is a Ratio metric
+                    const isRatio = metric.visualization_type === 'number' &&
+                                   metric.visualization_config &&
+                                   (metric.visualization_config as any)._frontendType === 'ratio';
+
+                    if (isRatio) {
+                      const config = metric.visualization_config as any;
+                      const fullDisplay = config.label
+                        ? `${config.label}${config.ratioValue || '1.0:1'}`
+                        : config.ratioValue || '1.0:1';
+
+                      return (
+                        <div key={metric.id} className="border border-border rounded-lg p-4">
+                          <h3 className="font-medium text-card-foreground mb-4">
+                            {metric.name}
+                          </h3>
+                          {metric.description && (
+                            <p className="text-sm text-muted-foreground mb-4">
+                              {metric.description}
+                            </p>
+                          )}
+                          <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
+                            <p className="text-sm text-neutral-600 mb-2">Ratio</p>
+                            <p className="text-3xl font-bold text-neutral-900">{fullDisplay}</p>
+                            {config.showTarget && config.targetValue && (
+                              <p className="text-sm text-neutral-500 mt-2">
+                                Target: {config.label}{config.targetValue}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    }
+
                     // Default metric rendering (progress bar)
                     return (
                       <div key={metric.id} className="border-l-4 border-primary pl-4">


### PR DESCRIPTION
## Summary
- Ratio metrics now display properly on public goal pages and overview modals
- Fixed detection logic to check for `_frontendType === 'ratio'` 
- Added proper rendering with metric name and ratio value display

## Problem
Ratio metrics (e.g., "Risk Ratio is 1.0:1") were not showing on public pages because:
1. They're stored as `visualization_type = 'number'` in the database
2. Public pages weren't checking for the `_frontendType` field to differentiate them
3. DistrictDashboard was checking for wrong Likert type ('likert-scale' instead of 'bar')

## Changes

### GoalDetail.tsx
- Added Ratio metric detection before default progress bar rendering
- Display includes metric name, ratio value, and optional target

### DistrictDashboard.tsx
- Added Ratio support for level 1 goals
- Fixed Ratio detection order for sub-goals (check before generic Number)
- Fixed Likert detection (now checks for 'bar' type with scaleMin)

## How Ratio Metrics Now Display

**Public Goal Pages:**
```
┌─────────────────────────────────┐
│ Ration 1.1.1                    │
├─────────────────────────────────┤
│ Ratio                           │
│                                 │
│ Risk Ratio is 1.0:1             │
│                                 │
│ Target: Risk Ratio is 0.5:1     │
│ (if showTarget enabled)         │
└─────────────────────────────────┘
```

**Modals:**
- Same layout, centered display
- Metric name above ratio value
- Clean, readable presentation

## Test Plan
- [ ] View Goal with Ratio metric on public page
- [ ] View Ratio metric in objective modal
- [ ] Verify metric name displays
- [ ] Verify ratio value displays correctly
- [ ] Verify target displays when enabled
- [ ] Verify Likert metrics still work
- [ ] Verify Number/KPI metrics still work

## Related
- PR #7 - Likert scale improvements (merged)
- Issue #9 - TypeScript improvements (addresses duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)