### PR TITLE
Fix Number/KPI metric display on public pages

### DIFF
--- a/src/pages/client/public/DistrictDashboard.tsx
+++ b/src/pages/client/public/DistrictDashboard.tsx
@@ -553,9 +553,9 @@ export function DistrictDashboard() {
                     const childProgress = child.overall_progress_override ?? child.overall_progress ?? 0;
                     const isExpanded = expandedGoalId === child.id;
 
-                    // Get real metrics for this goal (only one metric per goal)
+                    // Get real metrics for this goal - prefer metrics with visualization_config
                     const goalMetrics = metrics?.filter(m => m.goal_id === child.id) || [];
-                    const primaryMetric = goalMetrics[0]; // Only one metric per goal now
+                    const primaryMetric = goalMetrics.find(m => m.visualization_config) || goalMetrics[0];
 
                     // Convert metric visualization_config.dataPoints to chart data format
                     const dataPoints = primaryMetric?.visualization_config?.dataPoints ||
@@ -660,6 +660,26 @@ export function DistrictDashboard() {
                                   )}
                                 </div>
                               </div>
+                            ) : (primaryMetric.visualization_type === 'number' && primaryMetric.visualization_config?._frontendType === 'number') ? (
+                              <div className="p-6 bg-white rounded-lg">
+                                <div className="text-center">
+                                  <div className="text-sm font-medium text-neutral-600 mb-2">{primaryMetric.name}</div>
+                                  <div className="text-4xl font-bold text-neutral-900 mb-1">
+                                    {(() => {
+                                      const decimals = primaryMetric.visualization_config?.decimals ?? 0;
+                                      const value = typeof primaryMetric.visualization_config?.currentValue === 'number'
+                                        ? primaryMetric.visualization_config.currentValue.toFixed(decimals)
+                                        : primaryMetric.visualization_config?.currentValue || '0';
+                                      return primaryMetric.visualization_config?.unit ? `${value}${primaryMetric.visualization_config.unit}` : value;
+                                    })()}
+                                  </div>
+                                  {primaryMetric.visualization_config?.targetValue && (
+                                    <div className="text-sm text-neutral-500 mt-2">
+                                      Target: {primaryMetric.visualization_config.targetValue.toFixed(primaryMetric.visualization_config?.decimals ?? 0)}{primaryMetric.visualization_config?.unit || ''}
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
                             ) : (
                               chartData && chartData.length > 0 && (
                                 <AnnualProgressChart
@@ -684,9 +704,9 @@ export function DistrictDashboard() {
                                     const isSubExpanded = expandedSubGoalId === subGoal.id;
                                     const subGoalProgress = subGoal.overall_progress_override ?? subGoal.overall_progress ?? 0;
 
-                                    // Get real metrics for this sub-goal (only one metric per goal)
+                                    // Get real metrics for this sub-goal - prefer metrics with visualization_config
                                     const subGoalMetrics = metrics?.filter(m => m.goal_id === subGoal.id) || [];
-                                    const primarySubMetric = subGoalMetrics[0]; // Only one metric per goal now
+                                    const primarySubMetric = subGoalMetrics.find(m => m.visualization_config) || subGoalMetrics[0];
 
                                     // Debug logging
                                     if (subGoal.goal_number === '1.1.1') {
@@ -769,23 +789,24 @@ export function DistrictDashboard() {
                                                     )}
                                                   </div>
                                                 </div>
-                                              ) : primarySubMetric.visualization_type === 'number' ? (
+                                              ) : (primarySubMetric.visualization_type === 'number' && primarySubMetric.visualization_config?._frontendType === 'number') ? (
                                                 <div className="p-6 bg-white">
                                                   <div className="text-center">
                                                     <div className="text-sm font-medium text-neutral-600 mb-2">
                                                       {primarySubMetric.name}
                                                     </div>
-                                                    <div className="text-5xl font-bold text-neutral-900 mb-1">
-                                                      {primarySubMetric.visualization_config?.currentValue || 0}
+                                                    <div className="text-4xl font-bold text-neutral-900 mb-1">
+                                                      {(() => {
+                                                        const decimals = primarySubMetric.visualization_config?.decimals ?? 0;
+                                                        const value = typeof primarySubMetric.visualization_config?.currentValue === 'number'
+                                                          ? primarySubMetric.visualization_config.currentValue.toFixed(decimals)
+                                                          : primarySubMetric.visualization_config?.currentValue || '0';
+                                                        return primarySubMetric.visualization_config?.unit ? `${value}${primarySubMetric.visualization_config.unit}` : value;
+                                                      })()}
                                                     </div>
-                                                    {primarySubMetric.visualization_config?.label && (
-                                                      <div className="text-base text-neutral-600 mt-2">
-                                                        {primarySubMetric.visualization_config.label}
-                                                      </div>
-                                                    )}
                                                     {primarySubMetric.visualization_config?.targetValue && (
                                                       <div className="text-sm text-neutral-500 mt-2">
-                                                        Target: {primarySubMetric.visualization_config.targetValue}
+                                                        Target: {primarySubMetric.visualization_config.targetValue.toFixed(primarySubMetric.visualization_config?.decimals ?? 0)}{primarySubMetric.visualization_config?.unit || ''}
                                                       </div>
                                                     )}
                                                   </div>
@@ -805,7 +826,7 @@ export function DistrictDashboard() {
                                                 </div>
                                               ) : (metricChartData && metricChartData.length > 0) ? (
                                                 <div className="p-5 bg-neutral-50">
-                                                  {primarySubMetric.visualization_type === 'likert-scale' ? (
+                                                  {(primarySubMetric.visualization_type === 'bar' && primarySubMetric.visualization_config?.scaleMin) ? (
                                                     <LikertScaleChart
                                                       data={metricChartData}
                                                       title={primarySubMetric.name || "Survey Results"}

--- a/src/pages/client/public/GoalDetail.tsx
+++ b/src/pages/client/public/GoalDetail.tsx
@@ -183,6 +183,47 @@ export function GoalDetail() {
                       );
                     }
 
+                    // Check if this is a Number/KPI metric
+                    const isNumber = metric.visualization_type === 'number' &&
+                                    metric.visualization_config &&
+                                    (metric.visualization_config as any)._frontendType === 'number';
+
+                    if (isNumber) {
+                      const config = metric.visualization_config as any;
+                      const decimals = config.decimals ?? 0;
+                      const formattedValue = typeof config.currentValue === 'number'
+                        ? config.currentValue.toFixed(decimals)
+                        : config.currentValue || '0';
+                      const valueWithUnit = config.unit
+                        ? `${formattedValue}${config.unit}`
+                        : formattedValue;
+                      const fullDisplay = config.label
+                        ? `${config.label} - ${valueWithUnit}`
+                        : valueWithUnit;
+
+                      return (
+                        <div key={metric.id} className="border border-border rounded-lg p-4">
+                          <h3 className="font-medium text-card-foreground mb-4">
+                            {metric.name}
+                          </h3>
+                          {metric.description && (
+                            <p className="text-sm text-muted-foreground mb-4">
+                              {metric.description}
+                            </p>
+                          )}
+                          <div className="bg-white border border-border rounded-lg p-6">
+                            <p className="text-sm text-neutral-600 mb-2">Current Value</p>
+                            <p className="text-4xl font-bold text-neutral-900">{fullDisplay}</p>
+                            {config.targetValue && (
+                              <p className="text-sm text-neutral-500 mt-2">
+                                Target: {config.targetValue.toFixed(decimals)}{config.unit || ''}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    }
+
                     // Default metric rendering (progress bar)
                     return (
                       <div key={metric.id} className="border-l-4 border-primary pl-4">


### PR DESCRIPTION
## Summary
- Number/KPI metrics now display properly on public goal pages and overview modals
- Fixed metric selection to prefer metrics with visualization_config (newer metrics)
- Added proper formatting with decimals, units, and target values

## Problem
Number/KPI metrics were not showing on public pages because:
1. Goals with multiple metrics were selecting the FIRST metric by creation date
2. Newer Number metrics with proper `visualization_config` were being ignored
3. Older "progress" type metrics with no config were selected instead
4. No rendering logic existed for `_frontendType === 'number'`

## Example
**Goal 1.1.2** has TWO metrics:
- "Reading Comprehension Score" (old, `visualization_type='progress'`, no config) ❌
- "1.1.2 Number" (new, `visualization_type='number'`, has config) ✅

**Before**: Showed nothing (picked old metric with no config)  
**After**: Shows "1.1.2 Number - 50students" (picks new metric with config)

## Changes

### Metric Selection Logic (Both Files)
```typescript
// Before:
const primaryMetric = goalMetrics[0];

// After:
const primaryMetric = goalMetrics.find(m => m.visualization_config) || goalMetrics[0];
```

**Impact**: Prefers metrics with modern visualization_config, falls back to first if none exist

### GoalDetail.tsx
- Added Number/KPI metric detection before default progress bar
- Display includes metric name, formatted value with unit, and optional target
- Respects decimal places configuration

### DistrictDashboard.tsx
- Added Number/KPI support for level 1 goals
- Added Number/KPI support for sub-goals
- Fixed Likert detection for sub-goals ('likert-scale' → 'bar' with scaleMin)
- Improved Number formatting (consistent decimals and units)
- Cleaned up sub-goal Number display (removed unnecessary label field)

## How Number Metrics Now Display

**Public Goal Pages:**
```
┌─────────────────────────────────┐
│ 1.1.2 Number                    │
├─────────────────────────────────┤
│ Current Value                   │
│                                 │
│ Metric Name - 50students        │
│                                 │
│ Target: 100students             │
│ (if target configured)          │
└─────────────────────────────────┘
```

**Modals:**
- Centered display
- Metric name above value
- Large 4xl text for readability
- Proper decimal formatting (0, 1, or 2 decimals)

## Test Plan
- [x] View Number metric on public goal page (Goal 1.1.2)
- [x] View Number metric in objective modal
- [x] Verify metric name displays
- [x] Verify value formats correctly with unit (50students)
- [x] Verify decimal places respected
- [x] Verify target displays when configured
- [ ] Verify Likert metrics still work
- [ ] Verify Ratio metrics still work

## Additional Fixes
- Fixed sub-goal Likert detection to use proper 'bar' type check
- Standardized font sizes (4xl for all Number displays)
- Consistent decimal formatting across views

## Related
- PR #7 - Likert scale improvements (merged)
- PR #11 - Ratio metric display (merged)
- Issue #9 - TypeScript improvements (addresses similar code patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)