### PR TITLE
fix: Display target indicator badges on third-level sub-goals

### DIFF
--- a/src/pages/client/public/DistrictDashboard.tsx
+++ b/src/pages/client/public/DistrictDashboard.tsx
@@ -749,6 +749,20 @@ export function DistrictDashboard() {
                                                 <p className="text-xs text-neutral-600 mt-1">{subGoal.description}</p>
                                               )}
                                             </div>
+                                            {subGoal.indicator_text && (
+                                              <div className="flex-shrink-0">
+                                                <span
+                                                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium"
+                                                  style={{
+                                                    backgroundColor: subGoal.indicator_color || '#10b981',
+                                                    color: '#ffffff'
+                                                  }}
+                                                >
+                                                  <span className="w-1.5 h-1.5 rounded-full bg-white/80" />
+                                                  {subGoal.indicator_text}
+                                                </span>
+                                              </div>
+                                            )}
                                           </div>
 
                                           {/* Performance Indicator for Sub-goal - Only show if enabled, no click action */}


### PR DESCRIPTION
## Summary
- Fixed missing target indicator badges on third-level sub-goals (e.g., 1.1.1)
- Badges now display consistently across all goal levels (0, 1, and 2)

## Problem
The target indicator badge ("On Target", "Off Target") was displaying on:
- ✅ Level 0 goals (Strategic Objectives, e.g., 1)
- ✅ Level 1 goals (Goals, e.g., 1.1)
- ❌ Level 2 goals (Sub-goals, e.g., 1.1.1) - **Missing**

## Solution
Added the indicator badge rendering code to the third-level sub-goal component in `DistrictDashboard.tsx`. The badge now appears in the same location and with the same styling as the other goal levels.

## Changes
- Modified `src/pages/client/public/DistrictDashboard.tsx` (lines 752-765)
- Added conditional rendering for `subGoal.indicator_text` and `subGoal.indicator_color`

## Test Plan
- [x] Visual testing on Westside district page
- [x] Verified badges appear on all three goal levels
- [x] Confirmed styling matches level 1 and level 2 goal badges

## Screenshots
See the attached screenshots showing the "Off Target" badge now appearing on goal 1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)