### PR TITLE
fix: Change default decimal places from 0 to 2 for number metrics

### DIFF
--- a/src/pages/client/public/DistrictDashboard.tsx
+++ b/src/pages/client/public/DistrictDashboard.tsx
@@ -666,7 +666,7 @@ export function DistrictDashboard() {
                                   <div className="text-sm font-medium text-neutral-600 mb-2">{primaryMetric.name}</div>
                                   <div className="text-4xl font-bold text-neutral-900 mb-1">
                                     {(() => {
-                                      const decimals = primaryMetric.visualization_config?.decimals ?? 0;
+                                      const decimals = primaryMetric.visualization_config?.decimals ?? 2;
                                       const value = typeof primaryMetric.visualization_config?.currentValue === 'number'
                                         ? primaryMetric.visualization_config.currentValue.toFixed(decimals)
                                         : primaryMetric.visualization_config?.currentValue || '0';
@@ -675,7 +675,7 @@ export function DistrictDashboard() {
                                   </div>
                                   {primaryMetric.visualization_config?.targetValue && (
                                     <div className="text-sm text-neutral-500 mt-2">
-                                      Target: {primaryMetric.visualization_config.targetValue.toFixed(primaryMetric.visualization_config?.decimals ?? 0)}{primaryMetric.visualization_config?.unit || ''}
+                                      Target: {primaryMetric.visualization_config.targetValue.toFixed(primaryMetric.visualization_config?.decimals ?? 2)}{primaryMetric.visualization_config?.unit || ''}
                                     </div>
                                   )}
                                 </div>
@@ -815,7 +815,7 @@ export function DistrictDashboard() {
                                                     </div>
                                                     <div className="text-4xl font-bold text-neutral-900 mb-1">
                                                       {(() => {
-                                                        const decimals = primarySubMetric.visualization_config?.decimals ?? 0;
+                                                        const decimals = primarySubMetric.visualization_config?.decimals ?? 2;
                                                         const value = typeof primarySubMetric.visualization_config?.currentValue === 'number'
                                                           ? primarySubMetric.visualization_config.currentValue.toFixed(decimals)
                                                           : primarySubMetric.visualization_config?.currentValue || '0';
@@ -824,7 +824,7 @@ export function DistrictDashboard() {
                                                     </div>
                                                     {primarySubMetric.visualization_config?.targetValue && (
                                                       <div className="text-sm text-neutral-500 mt-2">
-                                                        Target: {primarySubMetric.visualization_config.targetValue.toFixed(primarySubMetric.visualization_config?.decimals ?? 0)}{primarySubMetric.visualization_config?.unit || ''}
+                                                        Target: {primarySubMetric.visualization_config.targetValue.toFixed(primarySubMetric.visualization_config?.decimals ?? 2)}{primarySubMetric.visualization_config?.unit || ''}
                                                       </div>
                                                     )}
                                                   </div>

--- a/src/pages/client/public/GoalDetail.tsx
+++ b/src/pages/client/public/GoalDetail.tsx
@@ -191,7 +191,7 @@ export function GoalDetail() {
 
                     if (isNumber) {
                       const config = metric.visualization_config as any;
-                      const decimals = config.decimals ?? 0;
+                      const decimals = config.decimals ?? 2;
                       const formattedValue = typeof config.currentValue === 'number'
                         ? config.currentValue.toFixed(decimals)
                         : config.currentValue || '0';


### PR DESCRIPTION
## Summary
- Fixed number/KPI metrics displaying rounded values (e.g., 0.85 showing as "1")
- Changed default decimal places from 0 to 2 in display components
- Ensures consistency with form input defaults

## Changes Made
- [GoalDetail.tsx](src/pages/client/public/GoalDetail.tsx#L194): Updated default decimals from 0 to 2
- [DistrictDashboard.tsx](src/pages/client/public/DistrictDashboard.tsx): Updated 4 occurrences of default decimals from 0 to 2

## Root Cause
The display logic was defaulting to 0 decimal places when the `decimals` field was not set in the database, causing values like 0.85 to round to "1". The form input component was already defaulting to 2 decimal places, creating an inconsistency.

## Test Plan
- [x] Verified dev server starts without errors
- [x] Confirmed changes align with MetricDataForm default behavior
- [ ] Test with existing metrics that have no decimals field set
- [ ] Test with metrics that explicitly set decimals to 0
- [ ] Verify display on both public pages and admin pages

## Impact
This change will affect any number/KPI metrics that don't have an explicit `decimals` value set in the database. They will now display with 2 decimal places instead of 0, which better preserves the precision of decimal values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)