### PR TITLE
fix: Include metric id when saving existing metrics

### DIFF
--- a/src/components/MetricBuilderWizard.tsx
+++ b/src/components/MetricBuilderWizard.tsx
@@ -204,7 +204,7 @@ export function MetricBuilderWizard({
       const isNumericMetric = selectedType === 'number' || selectedType === 'percentage';
 
       // Production now has full schema with all columns from migrations 001-016
-      const metric = {
+      const metric: any = {
         goal_id: goalId,
         name: metricDetails.name,
         description: metricDetails.description,
@@ -220,6 +220,11 @@ export function MetricBuilderWizard({
         data_source: 'survey' as const,
         metric_type: selectedType === 'percentage' ? 'percent' : 'number' as const
       };
+
+      // Include id when editing existing metric
+      if (existingMetric?.id) {
+        metric.id = existingMetric.id;
+      }
 
       console.log('[MetricBuilderWizard] Saving metric:', existingMetric ? 'UPDATE' : 'CREATE', metric);
       console.log('[MetricBuilderWizard] Metric data structure:', {

--- a/src/components/MetricBuilderWizard.tsx
+++ b/src/components/MetricBuilderWizard.tsx
@@ -204,7 +204,7 @@ export function MetricBuilderWizard({
       const isNumericMetric = selectedType === 'number' || selectedType === 'percentage';
 
       // Production now has full schema with all columns from migrations 001-016
-      const metric: any = {
+      const metric: Partial<Metric> = {
         goal_id: goalId,
         name: metricDetails.name,
         description: metricDetails.description,


### PR DESCRIPTION
## Summary
Fixes production bug where editing metrics threw "Cannot read properties of undefined (reading 'id')" error.

## Root Cause
`MetricBuilderWizard` was not including the metric `id` in the data object passed to `onSave()` when editing existing metrics. The parent component (`ObjectiveBuilder`) relied on its own `editingMetric` state to get the id, creating a potential race condition if state changed between opening the wizard and saving.

## Changes
- Added `existingMetric.id` to the metric object when editing ([MetricBuilderWizard.tsx:224-227](src/components/MetricBuilderWizard.tsx#L224-L227))
- Prevents undefined id errors during metric updates
- Follows defensive programming by making the save handler self-contained

## Test Plan
- [x] Build passes locally
- [x] TypeScript compilation succeeds
- [ ] Manual test: Edit existing metric → Save → No errors
- [ ] Verify in production after merge

## Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Severity
- [x] High - Production bug affecting metric editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)