### PR TITLE
feat: Redesign ObjectiveCard and fix visual badge display

### DIFF
--- a/src/components/goals-v2/GoalsTreePanel.tsx
+++ b/src/components/goals-v2/GoalsTreePanel.tsx
@@ -206,13 +206,17 @@ function GoalTreeNode({
           )}
         </div>
 
-        {/* Status indicator */}
+        {/* Status indicator badge */}
         {goal.indicator_text && (
-          <div
-            className="w-2 h-2 rounded-full flex-shrink-0"
-            style={{ backgroundColor: goal.indicator_color || '#10b981' }}
-            title={goal.indicator_text}
-          />
+          <span
+            className="ml-auto px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0"
+            style={{
+              backgroundColor: `${goal.indicator_color || '#10b981'}20`,
+              color: goal.indicator_color || '#10b981',
+            }}
+          >
+            {goal.indicator_text}
+          </span>
         )}
       </div>
 

--- a/src/components/public/GoalCardWithMetrics.tsx
+++ b/src/components/public/GoalCardWithMetrics.tsx
@@ -306,13 +306,6 @@ function CompactMetricCard({ metric, index }: { metric: Metric; index: number })
 }
 
 export function GoalCardWithMetrics({ goal, metrics, children, colorClass = 'bg-gray-100' }: GoalCardWithMetricsProps) {
-  // Get manual status set by admin (stored in overall_progress_custom_value)
-  const validStatuses = ['on-target', 'needs-attention', 'off-track', 'not-started', 'on-track', 'complete'];
-  const manualStatus = goal.overall_progress_custom_value?.toLowerCase().replace(/\s+/g, '-');
-  const status = validStatuses.includes(manualStatus || '')
-    ? (manualStatus as 'on-target' | 'needs-attention' | 'off-track' | 'not-started')
-    : 'not-started';
-
   const goalMetrics = metrics.filter(m => m.goal_id === goal.id);
 
   return (
@@ -333,7 +326,6 @@ export function GoalCardWithMetrics({ goal, metrics, children, colorClass = 'bg-
               <h3 className="text-sm font-semibold text-gray-900 line-clamp-2">
                 {goal.title}
               </h3>
-              <StatusBadge status={status} size="sm" />
             </div>
             {goal.description && (
               <p className="text-xs text-gray-500 line-clamp-2">

--- a/src/components/public/ObjectiveCard.tsx
+++ b/src/components/public/ObjectiveCard.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router-dom';
-import { ChevronRight, Target, BarChart3 } from 'lucide-react';
+import { ChevronRight, Target } from 'lucide-react';
 import type { Goal, Metric } from '../../lib/types';
 import { StatusBadge } from './StatusBadge';
 
@@ -43,42 +43,20 @@ function getColor(goal: Goal, index: number): keyof typeof colorConfig {
   return defaultColors[index % defaultColors.length];
 }
 
-export function ObjectiveCard({ objective, childGoals, metrics, index }: ObjectiveCardProps) {
+export function ObjectiveCard({ objective, childGoals, metrics: _metrics, index }: ObjectiveCardProps) {
   const { slug } = useParams();
   const color = getColor(objective, index);
   const colors = colorConfig[color];
 
-  // Get metrics for this objective and its children
-  const objectiveMetrics = metrics.filter(m =>
-    m.goal_id === objective.id || childGoals.some(g => g.id === m.goal_id)
-  );
-
-  // Find hero metric (first metric with is_primary flag, or first metric)
-  const heroMetric = objectiveMetrics.find(m => m.is_primary) || objectiveMetrics[0];
-
-  // Get manual status set by admin (stored in overall_progress_custom_value)
-  // Valid values: 'on-target', 'needs-attention', 'off-track', 'not-started'
+  // Get manual status set by admin (stored in indicator_text)
+  // Default to 'on-target' to match admin2 behavior (which shows "On Target" when no status is set)
   const validStatuses = ['on-target', 'needs-attention', 'off-track', 'not-started', 'on-track', 'complete'];
-  const manualStatus = objective.overall_progress_custom_value?.toLowerCase().replace(/\s+/g, '-');
+  // Use indicator_text (set via badge UI) first, fall back to overall_progress_custom_value for backwards compat
+  const statusText = objective.indicator_text || objective.overall_progress_custom_value;
+  const manualStatus = statusText?.toLowerCase().replace(/\s+/g, '-');
   const status = validStatuses.includes(manualStatus || '')
     ? (manualStatus as 'on-target' | 'needs-attention' | 'off-track' | 'not-started')
-    : 'not-started';
-
-  // Format hero metric value
-  const formatMetricValue = (metric: Metric) => {
-    const value = metric.current_value ?? metric.actual_value ?? 0;
-
-    if (metric.metric_type === 'percent' || metric.is_percentage) {
-      return { value: value.toFixed(0), unit: '%' };
-    }
-    if (metric.metric_type === 'rating') {
-      return { value: value.toFixed(2), unit: `/ ${metric.target_value || 5}` };
-    }
-    if (metric.metric_type === 'currency') {
-      return { value: `$${value.toLocaleString()}`, unit: '' };
-    }
-    return { value: value.toString(), unit: metric.unit || '' };
-  };
+    : 'on-target';  // Default to on-target to match admin2
 
   return (
     <Link
@@ -86,21 +64,19 @@ export function ObjectiveCard({ objective, childGoals, metrics, index }: Objecti
       className={`group block bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden border-t-[3px] ${colors.border} hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200`}
     >
       <div className="p-6">
-        {/* Header: Number badge + Title + Goal count */}
+        {/* Header: Number badge + Title + Status Badge */}
         <div className="flex items-start justify-between mb-3">
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
             <div
-              className={`w-8 h-8 rounded-lg ${colors.badge} ${colors.badgeText} flex items-center justify-center font-display font-semibold text-sm`}
+              className={`w-8 h-8 rounded-lg ${colors.badge} ${colors.badgeText} flex items-center justify-center font-display font-semibold text-sm flex-shrink-0`}
             >
               {objective.goal_number}
             </div>
-            <h3 className="font-display font-semibold text-lg text-gray-900 tracking-tight group-hover:text-gray-700 transition-colors">
+            <h3 className="font-display font-semibold text-lg text-gray-900 tracking-tight group-hover:text-gray-700 transition-colors truncate">
               {objective.title}
             </h3>
           </div>
-          <span className="text-xs font-medium text-gray-400 bg-gray-50 px-2 py-1 rounded">
-            {childGoals.length} goal{childGoals.length !== 1 ? 's' : ''}
-          </span>
+          <StatusBadge status={status} size="sm" />
         </div>
 
         {/* Description */}
@@ -108,33 +84,14 @@ export function ObjectiveCard({ objective, childGoals, metrics, index }: Objecti
           {objective.description || objective.executive_summary || 'Strategic objective for organizational growth and excellence.'}
         </p>
 
-        {/* Metrics Summary */}
-        <div className="flex items-center gap-4 mb-4 text-xs text-gray-400">
-          <div className="flex items-center gap-1">
-            <Target className="w-3.5 h-3.5" />
-            <span>{childGoals.length} Goals</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <BarChart3 className="w-3.5 h-3.5" />
-            <span>{objectiveMetrics.length} Metrics</span>
-          </div>
+        {/* Goals Count */}
+        <div className="flex items-center gap-1 mb-4 text-xs text-gray-400">
+          <Target className="w-3.5 h-3.5" />
+          <span>{childGoals.length} Goals</span>
         </div>
 
-        {/* Footer: Status + Hero metric + View details */}
-        <div className="flex items-center justify-between pt-4 border-t border-gray-50">
-          <div className="flex items-center gap-3">
-            <StatusBadge status={status} size="sm" />
-            {heroMetric && (
-              <div className="flex items-baseline gap-1">
-                <span className="font-display font-semibold text-xl text-gray-900">
-                  {formatMetricValue(heroMetric).value}
-                </span>
-                <span className="text-sm text-gray-400">
-                  {formatMetricValue(heroMetric).unit}
-                </span>
-              </div>
-            )}
-          </div>
+        {/* Footer: View details */}
+        <div className="flex items-center justify-end pt-4 border-t border-gray-50">
           <span className="flex items-center gap-1 text-xs font-medium text-gray-400 group-hover:text-district-red transition-colors">
             View details
             <ChevronRight className="w-4 h-4" />

--- a/src/pages/client/admin/AdminGoals.tsx
+++ b/src/pages/client/admin/AdminGoals.tsx
@@ -150,6 +150,17 @@ export function AdminGoals() {
                   <p className={`${isObjective ? 'font-bold text-lg' : 'font-medium'}`}>
                     {goal.goal_number} {goal.title}
                   </p>
+                  {goal.indicator_text && (
+                    <span
+                      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                      style={{
+                        backgroundColor: `${goal.indicator_color || '#10b981'}20`,
+                        color: goal.indicator_color || '#10b981',
+                      }}
+                    >
+                      {goal.indicator_text}
+                    </span>
+                  )}
                 </div>
                 {goal.description && (
                   <p className="text-sm text-muted-foreground mt-1">
@@ -304,6 +315,17 @@ export function AdminGoals() {
                         <span className="inline-flex items-center justify-center px-2 py-0.5 rounded text-xs font-semibold bg-blue-100 text-blue-800">
                           {goal.goal_number}
                         </span>
+                        {goal.indicator_text && (
+                          <span
+                            className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                            style={{
+                              backgroundColor: `${goal.indicator_color || '#10b981'}20`,
+                              color: goal.indicator_color || '#10b981',
+                            }}
+                          >
+                            {goal.indicator_text}
+                          </span>
+                        )}
                       </div>
                       <h3 className="font-semibold text-sm sm:text-base text-foreground line-clamp-2">
                         {goal.title}

--- a/src/pages/client/public/DistrictDashboard.tsx
+++ b/src/pages/client/public/DistrictDashboard.tsx
@@ -162,10 +162,8 @@ export function DistrictDashboard() {
               const status = getGoalStatus(goal.indicator_text);
               const isOffTrack = status === 'off-track';
 
-              // Gradient bar color based on status
-              const gradientClass = isOffTrack
-                ? 'from-amber-500 via-orange-600 to-red-600'
-                : 'from-emerald-400 via-emerald-500 to-teal-500';
+              // Use saved indicator_color, or fall back to status-based colors
+              const badgeColor = goal.indicator_color || (isOffTrack ? '#f59e0b' : '#10b981');
 
               return (
                 <article
@@ -176,8 +174,11 @@ export function DistrictDashboard() {
                     setShowSlidePanel(true);
                   }}
                 >
-                  {/* Top gradient bar */}
-                  <div className={`h-1 w-full bg-gradient-to-r ${gradientClass}`} />
+                  {/* Top gradient bar - uses saved indicator_color */}
+                  <div
+                    className="h-1 w-full"
+                    style={{ backgroundColor: badgeColor }}
+                  />
 
                   <div className="flex h-full flex-col p-6 md:p-7">
                     {/* Header with title and menu */}
@@ -190,19 +191,23 @@ export function DistrictDashboard() {
                           {goal.description || 'Strategic initiatives focused on this objective'}
                         </p>
 
-                        {/* Status badge below description */}
+                        {/* Status badge below description - uses saved indicator_color */}
                         <div className="mt-3">
-                          {isOffTrack ? (
-                            <button className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 ring-1 ring-amber-300 hover:bg-amber-100 hover:text-amber-800 hover:ring-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50">
+                          <span
+                            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium"
+                            style={{
+                              backgroundColor: `${badgeColor}20`,
+                              color: badgeColor,
+                              border: `1px solid ${badgeColor}40`,
+                            }}
+                          >
+                            {isOffTrack ? (
                               <AlertTriangle className="h-3.5 w-3.5" strokeWidth={1.5} />
-                              {goal.indicator_text || 'Off Track'}
-                            </button>
-                          ) : (
-                            <button className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-300 hover:bg-emerald-100 hover:text-emerald-800 hover:ring-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50">
+                            ) : (
                               <Check className="h-3.5 w-3.5" strokeWidth={1.5} />
-                              {goal.indicator_text || 'On Target'}
-                            </button>
-                          )}
+                            )}
+                            {goal.indicator_text || (isOffTrack ? 'Off Track' : 'On Target')}
+                          </span>
                         </div>
                       </div>
                       <button

--- a/src/pages/client/public/ObjectiveDetail.tsx
+++ b/src/pages/client/public/ObjectiveDetail.tsx
@@ -151,13 +151,16 @@ export function ObjectiveDetail() {
     return aNum - bNum;
   });
 
-  // Helper to get manual status set by admin (stored in overall_progress_custom_value)
+  // Helper to get manual status set by admin (stored in indicator_text)
+  // Default to 'on-target' to match admin2 behavior
   const getManualStatus = (goal: Goal): StatusType => {
     const validStatuses = ['on-target', 'needs-attention', 'off-track', 'not-started', 'on-track', 'complete'];
-    const manualStatus = goal.overall_progress_custom_value?.toLowerCase().replace(/\s+/g, '-');
+    // Use indicator_text (set via badge UI) first, fall back to overall_progress_custom_value for backwards compat
+    const statusText = goal.indicator_text || goal.overall_progress_custom_value;
+    const manualStatus = statusText?.toLowerCase().replace(/\s+/g, '-');
     return validStatuses.includes(manualStatus || '')
       ? (manualStatus as StatusType)
-      : 'not-started';
+      : 'on-target';  // Default to on-target to match admin2
   };
 
   const status = getManualStatus(objective);


### PR DESCRIPTION
## Summary
- Redesigned ObjectiveCard layout: status badge moved next to title, removed metrics count and confusing hero metric display
- Fixed visual badges across all views to properly read from `indicator_text` field (set via admin badge UI)
- Added consistent badge pill styling to AdminGoals, GoalsTreePanel, and DistrictDashboard
- Defaulted status to "On Target" when no status is set (matching admin2 behavior)

## Changes
| File | Change |
|------|--------|
| `ObjectiveCard.tsx` | Redesigned layout, removed hero metric, moved badge to header |
| `ObjectiveDetail.tsx` | Default to 'on-target' status |
| `GoalCardWithMetrics.tsx` | Removed redundant badge from header (kept in metric area) |
| `AdminGoals.tsx` | Added badge pills to desktop table and mobile cards |
| `GoalsTreePanel.tsx` | Replaced tiny dot with readable badge pill |
| `DistrictDashboard.tsx` | Use saved indicator_color for badge styling |

## Test plan
- [ ] Verify ObjectiveCard shows status badge next to title
- [ ] Verify goals show "On Target" by default when no status is set
- [ ] Verify badge colors match what's set in admin
- [ ] Verify metric area still shows status badges on goal cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)