### PR TITLE
fix: Fix admin subdomain navigation for district management

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,0 +1,61 @@
+# Commit, Push, and Create PR
+
+## Pre-computed Context
+
+**Current branch:**
+```bash
+git branch --show-current
+```
+
+**Base branch status:**
+```bash
+git fetch origin main --quiet 2>/dev/null; git rev-list --count HEAD..origin/main 2>/dev/null || echo "0"
+```
+
+**Staged changes:**
+```bash
+git diff --cached --stat
+```
+
+**Unstaged changes:**
+```bash
+git status --short
+```
+
+**Recent commits on this branch:**
+```bash
+git log origin/main..HEAD --oneline 2>/dev/null || git log -3 --oneline
+```
+
+**Full staged diff:**
+```bash
+git diff --cached
+```
+
+---
+
+## Instructions
+
+Assume `/pre-commit` checks have passed. Based on the staged changes above:
+
+1. **If nothing is staged**: Run `git add -A` first, then show me what will be committed
+
+2. **Write a conventional commit message** following project conventions:
+   - Format: `type: description` (e.g., `feat: add recipe timer component`)
+   - Types: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+   - Keep subject line under 72 characters
+   - Add body if changes are complex
+
+3. **Show me the commit message and ask for confirmation** before executing
+
+4. **After confirmation**:
+   - Commit with the approved message
+   - Push to origin (create remote branch if needed)
+   - Create a PR targeting `main` with:
+     - Clear title matching the commit
+     - Body summarizing what changed and why
+     - Reference any relevant context from the diff
+
+5. **If branch is behind main**: Warn me before proceeding - I may need to rebase first
+
+$ARGUMENTS

--- a/src/layouts/ClientAdminEditorialLayout.tsx
+++ b/src/layouts/ClientAdminEditorialLayout.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { Outlet, Link, useParams, useNavigate, useLocation } from 'react-router-dom';
+import { Outlet, Link, useNavigate, useLocation } from 'react-router-dom';
+import { useSubdomain } from '../contexts/SubdomainContext';
 import {
   Home,
   Target,
@@ -24,16 +25,16 @@ import { useAuth } from '../contexts/AuthContext';
  * Inspired by OKR/strategic planning tools with warm paper aesthetic
  */
 export function ClientAdminEditorialLayout() {
-  const { slug } = useParams<{ slug: string }>();
+  const { slug } = useSubdomain();
   const navigate = useNavigate();
   const location = useLocation();
-  const { data: district, isLoading } = useDistrict(slug!);
+  const { data: district, isLoading } = useDistrict(slug || '');
   const { user, logout } = useAuth();
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
 
-  const basePath = `/${slug}/admin`;
+  const basePath = '/admin';
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -139,7 +140,7 @@ export function ClientAdminEditorialLayout() {
 
           {/* View Public Site */}
           <a
-            href={`/${slug}`}
+            href="/"
             className="flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm font-medium transition-all text-[#9a9a9a] hover:bg-[#2a2a2a] hover:text-white"
           >
             <Eye className="h-[18px] w-[18px] opacity-70" />

--- a/src/pages/admin/SystemDashboard.tsx
+++ b/src/pages/admin/SystemDashboard.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Building2, Plus, Eye, Settings, Trash2, Search, Users, Target, BarChart3, Loader2, X, Edit2 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { useDistricts, useCreateDistrict, useDeleteDistrict, useUpdateDistrict } from '../../hooks/useDistricts';
+import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
 import type { District } from '../../lib/types';
 
 /**
@@ -11,7 +11,6 @@ import type { District } from '../../lib/types';
  * Displays all districts and allows system-level management
  */
 export function SystemDashboard() {
-  const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingDistrict, setEditingDistrict] = useState<District | null>(null);
@@ -221,7 +220,7 @@ export function SystemDashboard() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate(`/${district.slug}/admin`)}
+                          onClick={() => window.location.href = buildSubdomainUrlWithPath('district', '/admin', district.slug)}
                         >
                           <Settings className="h-4 w-4" />
                         </Button>

--- a/src/pages/client/admin/AdminDashboard2.tsx
+++ b/src/pages/client/admin/AdminDashboard2.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useSubdomain } from '../../../contexts/SubdomainContext';
 import {
   Plus,
   Minus,
@@ -25,8 +26,8 @@ import { useGoals } from '../../../hooks/useGoals';
  * Updated: Title/Description split
  */
 export function AdminDashboard2() {
-  const { slug } = useParams();
-  const { data: district } = useDistrict(slug!);
+  const { slug } = useSubdomain();
+  const { data: district } = useDistrict(slug || '');
   const { data: goals, isLoading: goalsLoading } = useGoals(district?.id || '');
 
   const [activeTab, setActiveTab] = useState<'all' | 'following'>('all');
@@ -128,7 +129,7 @@ export function AdminDashboard2() {
           </div>
           <div className="flex items-center gap-3">
             <Link
-              to={`/${slug}/admin/objectives/create`}
+              to="/admin/objectives/create"
               className="bg-[#b85c38] text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-[#a04d2d] transition-colors"
             >
               Create new strategic objective
@@ -415,7 +416,7 @@ export function AdminDashboard2() {
                     {/* Title and Description - stacked vertically */}
                     <div className="flex-1 min-w-0 flex flex-col gap-1">
                       <Link
-                        to={`/${slug}/admin/objectives/${objective.id}/edit`}
+                        to={`/admin/objectives/${objective.id}/edit`}
                         className="text-[15px] font-bold text-[#1a1a1a] leading-snug hover:text-[#b85c38] hover:underline transition-colors"
                         data-testid="objective-title"
                       >
@@ -484,7 +485,7 @@ export function AdminDashboard2() {
                               {/* Title and Description */}
                               <div className="flex-1 min-w-0 flex flex-col gap-0.5">
                                 <Link
-                                  to={`/${slug}/admin/objectives/${child.id}/edit`}
+                                  to={`/admin/objectives/${child.id}/edit`}
                                   className="text-[14px] font-semibold text-[#1a1a1a] leading-snug hover:text-[#b85c38] hover:underline transition-colors"
                                   data-testid="child-goal-title"
                                 >
@@ -535,7 +536,7 @@ export function AdminDashboard2() {
                                     {/* Title and Description */}
                                     <div className="flex-1 min-w-0 flex flex-col gap-0.5">
                                       <Link
-                                        to={`/${slug}/admin/objectives/${grandchild.id}/edit`}
+                                        to={`/admin/objectives/${grandchild.id}/edit`}
                                         className="text-[14px] font-semibold text-[#1a1a1a] leading-snug hover:text-[#b85c38] hover:underline transition-colors"
                                         data-testid="grandchild-goal-title"
                                       >

--- a/src/pages/client/admin/CreateObjective.tsx
+++ b/src/pages/client/admin/CreateObjective.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useSubdomain } from '../../../contexts/SubdomainContext';
 import {
   ChevronRight,
   Plus,
@@ -38,9 +39,9 @@ interface StoredGoal {
  * Now with enhanced GoalEditor for adding goals with metrics
  */
 export function CreateObjective() {
-  const { slug } = useParams();
+  const { slug } = useSubdomain();
   const navigate = useNavigate();
-  const { data: district } = useDistrict(slug!);
+  const { data: district } = useDistrict(slug || '');
   const { data: existingGoals } = useGoals(district?.id || '');
   const createGoal = useCreateGoal();
 
@@ -170,7 +171,7 @@ export function CreateObjective() {
       }
 
       // Navigate to the objectives list
-      navigate(`/${slug}/admin/objectives`);
+      navigate('/admin/objectives');
     } catch (error) {
       console.error('Failed to create objective:', error);
     } finally {
@@ -192,7 +193,7 @@ export function CreateObjective() {
       <div className="px-10 py-8 max-w-[1100px]">
         {/* Breadcrumb */}
         <nav className="flex items-center gap-2 text-[13px] text-[#8a8a8a] mb-6">
-          <Link to={`/${slug}/admin/objectives`} className="hover:text-[#4a4a4a] transition-colors">
+          <Link to="/admin/objectives" className="hover:text-[#4a4a4a] transition-colors">
             All objectives
           </Link>
           <ChevronRight className="h-3.5 w-3.5" />
@@ -206,7 +207,7 @@ export function CreateObjective() {
           </h1>
           <p className="text-[14px] text-[#6a6a6a]">
             To create strategic objectives with more advanced settings, go to the{' '}
-            <Link to={`/${slug}/admin/settings/objectives`} className="text-[#4a6fa5] hover:underline">
+            <Link to="/admin/settings/objectives" className="text-[#4a6fa5] hover:underline">
               Strategic objectives settings page
             </Link>.
           </p>

--- a/src/pages/client/admin/EditObjective.tsx
+++ b/src/pages/client/admin/EditObjective.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useSubdomain } from '../../../contexts/SubdomainContext';
 import {
   ChevronRight,
   Plus,
@@ -40,9 +41,10 @@ interface StoredGoal {
  * Loads existing objective data and allows editing
  */
 export function EditObjective() {
-  const { slug, objectiveId } = useParams();
+  const { objectiveId } = useParams();
+  const { slug } = useSubdomain();
   const navigate = useNavigate();
-  const { data: district } = useDistrict(slug!);
+  const { data: district } = useDistrict(slug || '');
   const { data: existingGoals } = useGoals(district?.id || '');
   const { data: objective, isLoading: objectiveLoading, error: objectiveError } = useGoal(objectiveId || '');
   const { data: childGoals } = useChildGoals(objectiveId || '');
@@ -214,7 +216,7 @@ export function EditObjective() {
       // This could be enhanced to handle creates/updates/deletes of children
 
       // Navigate back to the objectives list
-      navigate(`/${slug}/admin/objectives`);
+      navigate('/admin/objectives');
     } catch (error) {
       console.error('Failed to update objective:', error);
     } finally {
@@ -252,7 +254,7 @@ export function EditObjective() {
             <h2 className="text-lg font-semibold text-[#1a1a1a] mb-2">Objective not found</h2>
             <p className="text-[#8a8a8a] mb-4">The objective you're looking for doesn't exist or you don't have access to it.</p>
             <Link
-              to={`/${slug}/admin/objectives`}
+              to="/admin/objectives"
               className="inline-flex items-center gap-2 text-[#4a6fa5] hover:underline"
             >
               <ChevronRight className="h-4 w-4 rotate-180" />
@@ -269,7 +271,7 @@ export function EditObjective() {
       <div className="px-10 py-8 max-w-[1100px]">
         {/* Breadcrumb */}
         <nav className="flex items-center gap-2 text-[13px] text-[#8a8a8a] mb-6">
-          <Link to={`/${slug}/admin/objectives`} className="hover:text-[#4a4a4a] transition-colors">
+          <Link to="/admin/objectives" className="hover:text-[#4a4a4a] transition-colors">
             All objectives
           </Link>
           <ChevronRight className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Fixes navigation from System Admin to District Admin when using subdomain-based routing.

**Problem:** Clicking the Settings (gear) icon on a district in System Admin navigated to an invalid URL within the same subdomain instead of the district's subdomain.

**Solution:** 
- Use `buildSubdomainUrlWithPath()` for cross-subdomain navigation
- Replace `useParams()` with `useSubdomain()` to get slug from subdomain context
- Update all navigation paths to remove redundant `/${slug}` prefix

## Changes

| File | Change |
|------|--------|
| `SystemDashboard.tsx` | Settings button navigates to correct district subdomain |
| `ClientAdminEditorialLayout.tsx` | Get slug from subdomain context instead of URL params |
| `AdminDashboard2.tsx` | Fix objective list navigation links |
| `CreateObjective.tsx` | Fix breadcrumb and save navigation |
| `EditObjective.tsx` | Fix breadcrumb and save navigation |
| `.claude/commands/commit-push-pr.md` | Add new slash command |

## Test plan

- [ ] Go to `admin.stratadash.org` (System Admin)
- [ ] Click Settings (gear) on a district row → Should navigate to `{slug}.stratadash.org/admin`
- [ ] Verify objectives list loads correctly
- [ ] Click objective title → Should navigate to edit page
- [ ] Click "Create new strategic objective" → Should work
- [ ] Save changes → Should return to objectives list

🤖 Generated with [Claude Code](https://claude.com/claude-code)