### PR TITLE
fix: Add consistent dark mode support to public pages

### DIFF
--- a/src/components/public/MobileHeader.tsx
+++ b/src/components/public/MobileHeader.tsx
@@ -33,12 +33,12 @@ export function MobileHeader({ district, onMenuToggle }: MobileHeaderProps) {
   };
 
   return (
-    <header className="sticky top-0 z-30 lg:hidden bg-white/80 backdrop-blur-md border-b border-gray-200 h-14 px-4 flex items-center justify-between">
+    <header className="sticky top-0 z-30 lg:hidden bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-gray-200 dark:border-slate-800 h-14 px-4 flex items-center justify-between">
       <div className="flex items-center">
         {/* Hamburger Menu */}
         <button
           onClick={onMenuToggle}
-          className="mr-3 text-gray-500 hover:text-gray-900 p-1 -ml-1"
+          className="mr-3 text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 p-1 -ml-1"
           aria-label="Open menu"
         >
           <Menu className="w-6 h-6" />
@@ -56,7 +56,7 @@ export function MobileHeader({ district, onMenuToggle }: MobileHeaderProps) {
               </div>
             );
           })()}
-          <span className="font-display font-semibold text-sm text-gray-900">
+          <span className="font-display font-semibold text-sm text-gray-900 dark:text-slate-100">
             {district.name.split(' ')[0]}
           </span>
         </Link>
@@ -64,7 +64,7 @@ export function MobileHeader({ district, onMenuToggle }: MobileHeaderProps) {
 
       {/* Context Indicator */}
       <div>
-        <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2 py-1 rounded">
+        <span className="text-xs font-medium text-gray-500 dark:text-slate-400 bg-gray-100 dark:bg-slate-800 px-2 py-1 rounded">
           {getContextLabel()}
         </span>
       </div>

--- a/src/components/public/PublicFooter.tsx
+++ b/src/components/public/PublicFooter.tsx
@@ -6,31 +6,31 @@ interface PublicFooterProps {
 
 export function PublicFooter({ district }: PublicFooterProps) {
   return (
-    <footer className="mt-20 border-t border-gray-200 pt-8 pb-4">
+    <footer className="mt-20 border-t border-gray-200 dark:border-slate-800 pt-8 pb-4">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
         {/* District info */}
-        <div className="flex flex-col sm:flex-row sm:items-center gap-4 text-xs text-gray-500">
-          <span className="font-medium text-gray-600">{district.name}</span>
+        <div className="flex flex-col sm:flex-row sm:items-center gap-4 text-xs text-gray-500 dark:text-slate-400">
+          <span className="font-medium text-gray-600 dark:text-slate-300">{district.name}</span>
         </div>
 
         {/* Links */}
         <div className="flex flex-wrap items-center gap-4 sm:gap-6 text-xs">
-          <a href="#" className="text-gray-500 hover:text-gray-700 transition-colors">
+          <a href="#" className="text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 transition-colors">
             Privacy Policy
           </a>
-          <a href="#" className="text-gray-500 hover:text-gray-700 transition-colors">
+          <a href="#" className="text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 transition-colors">
             Accessibility
           </a>
-          <a href="#" className="text-gray-500 hover:text-gray-700 transition-colors">
+          <a href="#" className="text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 transition-colors">
             Contact
           </a>
-          <div className="flex items-center gap-2 text-gray-400">
+          <div className="flex items-center gap-2 text-gray-400 dark:text-slate-500">
             <span>Powered by</span>
             <a
               href="https://stratadash.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-semibold text-gray-500 hover:text-gray-700 transition-colors"
+              className="font-semibold text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 transition-colors"
             >
               StrataDash
             </a>

--- a/src/components/public/Sidebar.tsx
+++ b/src/components/public/Sidebar.tsx
@@ -32,28 +32,28 @@ interface SidebarProps {
 // Color mapping for objective badges
 const colorClasses = {
   red: {
-    badge: 'bg-white text-district-red border-red-100',
-    badgeActive: 'bg-white text-district-red border-red-100 shadow-sm',
+    badge: 'bg-white dark:bg-slate-800 text-district-red border-red-100 dark:border-red-900',
+    badgeActive: 'bg-white dark:bg-slate-800 text-district-red border-red-100 dark:border-red-900 shadow-sm',
     text: 'text-district-red',
-    bg: 'bg-red-50',
+    bg: 'bg-red-50 dark:bg-red-950',
   },
   blue: {
-    badge: 'bg-white text-district-blue border-blue-100',
-    badgeActive: 'bg-white text-district-blue border-blue-100 shadow-sm',
+    badge: 'bg-white dark:bg-slate-800 text-district-blue border-blue-100 dark:border-blue-900',
+    badgeActive: 'bg-white dark:bg-slate-800 text-district-blue border-blue-100 dark:border-blue-900 shadow-sm',
     text: 'text-district-blue',
-    bg: 'bg-blue-50',
+    bg: 'bg-blue-50 dark:bg-blue-950',
   },
   amber: {
-    badge: 'bg-white text-district-amber border-amber-100',
-    badgeActive: 'bg-white text-district-amber border-amber-100 shadow-sm',
+    badge: 'bg-white dark:bg-slate-800 text-district-amber border-amber-100 dark:border-amber-900',
+    badgeActive: 'bg-white dark:bg-slate-800 text-district-amber border-amber-100 dark:border-amber-900 shadow-sm',
     text: 'text-district-amber',
-    bg: 'bg-amber-50',
+    bg: 'bg-amber-50 dark:bg-amber-950',
   },
   green: {
-    badge: 'bg-white text-district-green border-green-100',
-    badgeActive: 'bg-white text-district-green border-green-100 shadow-sm',
+    badge: 'bg-white dark:bg-slate-800 text-district-green border-green-100 dark:border-green-900',
+    badgeActive: 'bg-white dark:bg-slate-800 text-district-green border-green-100 dark:border-green-900 shadow-sm',
     text: 'text-district-green',
-    bg: 'bg-green-50',
+    bg: 'bg-green-50 dark:bg-green-950',
   },
 };
 
@@ -138,7 +138,7 @@ export function Sidebar({ district, objectives, goals, isOpen, onClose, isLoadin
   return (
     <>
       {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex fixed inset-y-0 left-0 z-50 w-72 bg-white border-r border-gray-200 flex-col">
+      <aside className="hidden lg:flex fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-slate-900 border-r border-gray-200 dark:border-slate-800 flex-col">
         <SidebarContent
           district={district}
           objectives={objectives}
@@ -156,16 +156,16 @@ export function Sidebar({ district, objectives, goals, isOpen, onClose, isLoadin
 
       {/* Mobile Sidebar (Drawer) */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-72 bg-white border-r border-gray-200 transform transition-transform duration-300 ease-in-out lg:hidden flex flex-col shadow-2xl ${
+        className={`fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-slate-900 border-r border-gray-200 dark:border-slate-800 transform transition-transform duration-300 ease-in-out lg:hidden flex flex-col shadow-2xl ${
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         {/* Close button */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-100">
-          <span className="font-display font-semibold text-gray-900">Menu</span>
+        <div className="flex items-center justify-between p-4 border-b border-gray-100 dark:border-slate-800">
+          <span className="font-display font-semibold text-gray-900 dark:text-slate-100">Menu</span>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 p-1"
+            className="text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 p-1"
             aria-label="Close menu"
           >
             <X className="w-5 h-5" />
@@ -342,7 +342,7 @@ function SidebarContent({
   return (
     <>
       {/* Logo Area */}
-      <div className="sticky top-0 z-10 bg-white/95 backdrop-blur-md border-b border-gray-100 px-6 h-16 flex items-center justify-between">
+      <div className="sticky top-0 z-10 bg-white/95 dark:bg-slate-900/95 backdrop-blur-md border-b border-gray-100 dark:border-slate-800 px-6 h-16 flex items-center justify-between">
         <Link to={homePath} className="flex items-center gap-3 min-w-0" onClick={onItemClick}>
           {(() => {
             const logoUrl = getLogoUrl(district, slug || '');
@@ -355,10 +355,10 @@ function SidebarContent({
             );
           })()}
           <div className="flex flex-col min-w-0">
-            <span className="font-display font-semibold text-sm tracking-tight text-gray-900 leading-none truncate max-w-[140px]">
+            <span className="font-display font-semibold text-sm tracking-tight text-gray-900 dark:text-slate-100 leading-none truncate max-w-[140px]">
               {district.name.split(' ')[0].toUpperCase()}
             </span>
-            <span className="text-[10px] uppercase tracking-widest text-gray-500 font-medium mt-0.5">
+            <span className="text-[10px] uppercase tracking-widest text-gray-500 dark:text-slate-400 font-medium mt-0.5">
               Strategic Plan
             </span>
           </div>
@@ -373,8 +373,8 @@ function SidebarContent({
           onClick={onItemClick}
           className={`relative flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
             isOverviewActive
-              ? 'bg-red-50 text-district-red'
-              : 'text-gray-600 hover:bg-gray-50'
+              ? 'bg-red-50 dark:bg-red-950 text-district-red'
+              : 'text-gray-600 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-800'
           }`}
         >
           {isOverviewActive && (
@@ -387,12 +387,12 @@ function SidebarContent({
         {/* Strategic Goals Section */}
         <div>
           <div className="px-3 mb-3 flex items-center justify-between">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-widest">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-widest">
               Strategic Goals
             </h3>
-            <div className="flex items-center shadow-sm border border-gray-200 rounded-md bg-white px-2 py-1">
-              <Calendar className="w-3 h-3 text-gray-400 mr-1.5" />
-              <span className="text-[10px] font-semibold text-gray-900">2021–2026</span>
+            <div className="flex items-center shadow-sm border border-gray-200 dark:border-slate-700 rounded-md bg-white dark:bg-slate-800 px-2 py-1">
+              <Calendar className="w-3 h-3 text-gray-400 dark:text-slate-500 mr-1.5" />
+              <span className="text-[10px] font-semibold text-gray-900 dark:text-slate-100">2021–2026</span>
             </div>
           </div>
 
@@ -400,7 +400,7 @@ function SidebarContent({
             <div className="space-y-2 px-3">
               {[1, 2, 3, 4].map(i => (
                 <div key={i} className="animate-pulse">
-                  <div className="h-10 bg-gray-100 rounded-lg" />
+                  <div className="h-10 bg-gray-100 dark:bg-slate-800 rounded-lg" />
                 </div>
               ))}
             </div>
@@ -420,7 +420,7 @@ function SidebarContent({
                       onClick={() => handleObjectiveClick(objective.id, isActive)}
                       data-testid={`objective-${objective.goal_number}`}
                       className={`relative w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors text-left ${
-                        isActive ? `${colors.bg} ${colors.text}` : 'text-gray-600 hover:bg-gray-50'
+                        isActive ? `${colors.bg} ${colors.text}` : 'text-gray-600 dark:text-slate-400 hover:bg-gray-50 dark:hover:bg-slate-800'
                       }`}
                     >
                       {isActive && (
@@ -444,7 +444,7 @@ function SidebarContent({
                           <ChevronRight
                             className={`w-4 h-4 flex-shrink-0 transition-transform ${
                               isExpanded ? 'rotate-90' : ''
-                            } ${isActive ? `text-${color}-300` : 'text-gray-400'}`}
+                            } ${isActive ? `text-${color}-300` : 'text-gray-400 dark:text-slate-500'}`}
                           />
                         </div>
                       </div>
@@ -454,7 +454,7 @@ function SidebarContent({
                     {isExpanded && childGoals.length > 0 && (
                       <div className="pl-4 pr-1 mt-1 space-y-0.5">
                         <div className="relative">
-                          <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-200" />
+                          <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-200 dark:bg-slate-700" />
                           {childGoals.map(goal => {
                             const isGoalActive = currentGoalId === goal.id;
                             const level2Children = getChildGoals(goal.id);
@@ -470,7 +470,7 @@ function SidebarContent({
                                     className={`w-full flex items-center justify-between pl-6 pr-2 py-2 text-xs font-medium rounded-md transition-colors text-left ${
                                       isGoalActive
                                         ? `${colors.text} ${colors.bg}/50`
-                                        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50'
+                                        : 'text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 hover:bg-gray-50 dark:hover:bg-slate-800'
                                     }`}
                                     title={`${goal.goal_number} ${goal.title}`}
                                   >
@@ -480,7 +480,7 @@ function SidebarContent({
                                     <ChevronRight
                                       className={`w-3 h-3 flex-shrink-0 ml-1 transition-transform ${
                                         isGoalExpanded ? 'rotate-90' : ''
-                                      } text-gray-400`}
+                                      } text-gray-400 dark:text-slate-500`}
                                     />
                                   </button>
                                 ) : (
@@ -489,7 +489,7 @@ function SidebarContent({
                                     className={`w-full text-left block pl-6 py-2 text-xs font-medium rounded-md transition-colors ${
                                       isGoalActive
                                         ? `${colors.text} ${colors.bg}/50`
-                                        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50'
+                                        : 'text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 hover:bg-gray-50 dark:hover:bg-slate-800'
                                     }`}
                                     title={`${goal.goal_number} ${goal.title}`}
                                   >
@@ -503,7 +503,7 @@ function SidebarContent({
                                 {hasChildren && isGoalExpanded && (
                                   <div className="pl-4 mt-0.5 space-y-0.5">
                                     <div className="relative">
-                                      <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-100" />
+                                      <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-100 dark:bg-slate-700" />
                                       {level2Children.map(initiative => {
                                         const isInitiativeActive = currentGoalId === initiative.id;
                                         return (
@@ -513,7 +513,7 @@ function SidebarContent({
                                             className={`w-full text-left block pl-6 py-1.5 text-[11px] font-medium rounded-md transition-colors ${
                                               isInitiativeActive
                                                 ? `${colors.text} ${colors.bg}/30`
-                                                : 'text-gray-400 hover:text-gray-700 hover:bg-gray-50'
+                                                : 'text-gray-400 dark:text-slate-500 hover:text-gray-700 dark:hover:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800'
                                             }`}
                                             title={`${initiative.goal_number} ${initiative.title}`}
                                           >
@@ -541,12 +541,12 @@ function SidebarContent({
       </nav>
 
       {/* Footer Link */}
-      <div className="p-4 border-t border-gray-100">
+      <div className="p-4 border-t border-gray-100 dark:border-slate-800">
         <a
           href={`https://www.${district.slug}.org`}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-3 px-3 py-2 text-xs font-medium text-gray-500 hover:text-gray-900 transition-colors"
+          className="flex items-center gap-3 px-3 py-2 text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 transition-colors"
         >
           <Home className="w-4 h-4" />
           Return to District Home

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -43,10 +43,10 @@ export function PublicLayout({ districtSlug }: PublicLayoutProps = {}) {
 
   if (districtLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-slate-950 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-district-red mx-auto"></div>
-          <p className="mt-4 text-gray-500 font-sans">Loading...</p>
+          <p className="mt-4 text-gray-500 dark:text-slate-400 font-sans">Loading...</p>
         </div>
       </div>
     );
@@ -54,9 +54,9 @@ export function PublicLayout({ districtSlug }: PublicLayoutProps = {}) {
 
   if (!district) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-slate-950 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-xl text-gray-500 font-sans">District not found</p>
+          <p className="text-xl text-gray-500 dark:text-slate-400 font-sans">District not found</p>
           <Link to="/" className="mt-4 inline-flex items-center text-district-red hover:underline font-sans">
             Return to Home
           </Link>
@@ -72,7 +72,7 @@ export function PublicLayout({ districtSlug }: PublicLayoutProps = {}) {
   const objectives = allGoals.filter(g => g.level === 0);
 
   return (
-    <div className="flex min-h-screen bg-gray-50 font-sans">
+    <div className="flex min-h-screen bg-gray-50 dark:bg-slate-950 font-sans">
       {/* Mobile backdrop overlay */}
       {sidebarOpen && (
         <div

--- a/src/pages/client/public/ObjectiveDetail.tsx
+++ b/src/pages/client/public/ObjectiveDetail.tsx
@@ -17,26 +17,26 @@ interface ObjectiveDetailContext {
 const colorConfig = {
   red: {
     badge: 'bg-district-red',
-    light: 'bg-red-50',
-    border: 'border-red-200',
+    light: 'bg-red-50 dark:bg-red-950',
+    border: 'border-red-200 dark:border-red-800',
     text: 'text-district-red',
   },
   blue: {
     badge: 'bg-district-blue',
-    light: 'bg-blue-50',
-    border: 'border-blue-200',
+    light: 'bg-blue-50 dark:bg-blue-950',
+    border: 'border-blue-200 dark:border-blue-800',
     text: 'text-district-blue',
   },
   amber: {
     badge: 'bg-district-amber',
-    light: 'bg-amber-50',
-    border: 'border-amber-200',
+    light: 'bg-amber-50 dark:bg-amber-950',
+    border: 'border-amber-200 dark:border-amber-800',
     text: 'text-district-amber',
   },
   green: {
     badge: 'bg-district-green',
-    light: 'bg-green-50',
-    border: 'border-green-200',
+    light: 'bg-green-50 dark:bg-green-950',
+    border: 'border-green-200 dark:border-green-800',
     text: 'text-district-green',
   },
 };
@@ -113,12 +113,12 @@ export function ObjectiveDetail() {
   if (isLoading) {
     return (
       <div className="animate-pulse space-y-6">
-        <div className="h-4 bg-gray-100 rounded w-1/4" />
+        <div className="h-4 bg-gray-100 dark:bg-slate-800 rounded w-1/4" />
         <div className="flex items-start gap-4">
-          <div className="w-14 h-14 bg-gray-100 rounded-lg" />
+          <div className="w-14 h-14 bg-gray-100 dark:bg-slate-800 rounded-lg" />
           <div className="flex-1">
-            <div className="h-8 bg-gray-100 rounded w-2/3 mb-2" />
-            <div className="h-1 bg-gray-100 rounded w-24" />
+            <div className="h-8 bg-gray-100 dark:bg-slate-800 rounded w-2/3 mb-2" />
+            <div className="h-1 bg-gray-100 dark:bg-slate-800 rounded w-24" />
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -133,7 +133,7 @@ export function ObjectiveDetail() {
   if (!objective) {
     return (
       <div className="text-center py-12">
-        <p className="text-xl text-gray-500">Objective not found</p>
+        <p className="text-xl text-gray-500 dark:text-slate-400">Objective not found</p>
         <Link to={`/${slug}`} className="mt-4 inline-flex items-center text-district-red hover:underline">
           Return to Overview
         </Link>
@@ -171,12 +171,12 @@ export function ObjectiveDetail() {
   return (
     <div className="space-y-8">
       {/* Breadcrumbs */}
-      <nav className="flex text-xs text-gray-500 space-x-2 items-center">
-        <Link to={`/${slug}`} className="hover:text-gray-900 transition-colors">
+      <nav className="flex text-xs text-gray-500 dark:text-slate-400 space-x-2 items-center">
+        <Link to={`/${slug}`} className="hover:text-gray-900 dark:hover:text-slate-100 transition-colors">
           Strategic Plan
         </Link>
-        <span className="text-gray-300">/</span>
-        <span className="text-gray-900 font-medium">{objective.goal_number} {objective.title}</span>
+        <span className="text-gray-300 dark:text-slate-600">/</span>
+        <span className="text-gray-900 dark:text-slate-100 font-medium">{objective.goal_number} {objective.title}</span>
       </nav>
 
       {/* Header with Number Badge and Title */}
@@ -188,12 +188,12 @@ export function ObjectiveDetail() {
         </div>
         <div className="max-w-3xl">
           <div className="flex items-center gap-3 mb-2 flex-wrap">
-            <h1 className="font-display font-semibold text-2xl lg:text-3xl text-gray-900 tracking-tight">
+            <h1 className="font-display font-semibold text-2xl lg:text-3xl text-gray-900 dark:text-slate-100 tracking-tight">
               {objective.title}
             </h1>
             <StatusBadge status={status} />
           </div>
-          <p className="text-gray-500 text-sm lg:text-base leading-relaxed">
+          <p className="text-gray-500 dark:text-slate-400 text-sm lg:text-base leading-relaxed">
             {objective.description || objective.executive_summary ||
               `This strategic objective encompasses our commitment to excellence and continuous improvement.`}
           </p>
@@ -240,10 +240,10 @@ export function ObjectiveDetail() {
 
       {/* Empty state for objectives with no goals */}
       {level1Goals.length === 0 && (
-        <div className="text-center py-12 bg-gray-50 rounded-xl border border-gray-100">
-          <FolderOpen className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No Goals Yet</h3>
-          <p className="text-sm text-gray-500 max-w-md mx-auto">
+        <div className="text-center py-12 bg-gray-50 dark:bg-slate-900 rounded-xl border border-gray-100 dark:border-slate-800">
+          <FolderOpen className="w-12 h-12 text-gray-300 dark:text-slate-600 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-slate-100 mb-2">No Goals Yet</h3>
+          <p className="text-sm text-gray-500 dark:text-slate-400 max-w-md mx-auto">
             This objective doesn't have any goals defined yet. Goals help track progress toward achieving this strategic objective.
           </p>
         </div>


### PR DESCRIPTION
## Summary

- Fixed inconsistent dark mode theming where goal cards correctly switched to dark mode but the sidebar, header, and footer remained light
- Added `dark:` Tailwind CSS variants to 5 components that were missing theme support

## Changes

| File | Changes |
|------|---------|
| `PublicLayout.tsx` | Dark mode for loading states and main container |
| `Sidebar.tsx` | Dark mode for navigation, badges, and all nested items |
| `ObjectiveDetail.tsx` | Dark mode for breadcrumbs, headers, and empty states |
| `MobileHeader.tsx` | Dark mode for mobile header and context indicator |
| `PublicFooter.tsx` | Dark mode for footer border and link colors |

## Test plan

- [ ] Navigate to a public district page (e.g., `/westside`)
- [ ] Click the theme toggle (sun/moon icon)
- [ ] Verify sidebar background switches from white to dark slate
- [ ] Verify all navigation items, badges, and text update colors
- [ ] Verify footer and mobile header also switch themes
- [ ] Test on mobile viewport as well

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added comprehensive dark mode theme support across multiple components including mobile header, footer, sidebar, and objective detail pages. Updated color schemes, text colors, border styles, and hover states to ensure consistent dark theme appearance with proper contrast and readability throughout the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->