### PR TITLE
fix: Use subdomain URLs for district admin links from system admin

### DIFF
--- a/src/components/admin/dashboard/DistrictCard.tsx
+++ b/src/components/admin/dashboard/DistrictCard.tsx
@@ -8,7 +8,7 @@ interface DistrictCardProps {
 
 export function DistrictCard({ district }: DistrictCardProps) {
   const publicUrl = buildSubdomainUrlWithPath('district', '', district.slug);
-  const adminUrl = `/${district.slug}/admin`;
+  const adminUrl = buildSubdomainUrlWithPath('district', '/admin', district.slug);
 
   const handleViewPublic = () => {
     window.open(publicUrl, '_blank');

--- a/src/components/admin/dashboard/DistrictGridItem.tsx
+++ b/src/components/admin/dashboard/DistrictGridItem.tsx
@@ -8,7 +8,7 @@ interface DistrictGridItemProps {
 
 export function DistrictGridItem({ district }: DistrictGridItemProps) {
   const publicUrl = buildSubdomainUrlWithPath('district', '', district.slug);
-  const adminUrl = `/${district.slug}/admin`;
+  const adminUrl = buildSubdomainUrlWithPath('district', '/admin', district.slug);
 
   const handleViewPublic = () => {
     window.open(publicUrl, '_blank');

--- a/src/components/admin/dashboard/__tests__/DistrictCard.test.tsx
+++ b/src/components/admin/dashboard/__tests__/DistrictCard.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DistrictCard } from '../DistrictCard';
+import type { DistrictWithStats } from '../../../../lib/services/systemAdmin.service';
+
+const mockDistrict: DistrictWithStats = {
+  id: '123',
+  name: 'Westside Community Schools',
+  slug: 'westside',
+  tagline: 'Community. Innovation. Excellence.',
+  is_public: true,
+  primary_color: '#C03537',
+  logo_url: undefined,
+  goals_count: 15,
+  schools_count: 0,
+  users_count: 1,
+};
+
+describe('DistrictCard', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Mock window.location for localhost
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'localhost',
+        port: '5173',
+        protocol: 'http:',
+        search: '?subdomain=admin',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('renders district name and stats', () => {
+    render(<DistrictCard district={mockDistrict} />);
+
+    expect(screen.getByText('Westside Community Schools')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument(); // goals
+    expect(screen.getByText('westside')).toBeInTheDocument(); // slug
+  });
+
+  it('renders admin link with correct subdomain URL for localhost', () => {
+    render(<DistrictCard district={mockDistrict} />);
+
+    const adminLink = screen.getByTitle('Open district admin');
+    expect(adminLink).toHaveAttribute(
+      'href',
+      'http://localhost:5173/admin?subdomain=westside'
+    );
+  });
+
+  it('renders public badge when district is public', () => {
+    render(<DistrictCard district={mockDistrict} />);
+    expect(screen.getByText('Public')).toBeInTheDocument();
+  });
+
+  it('renders private badge when district is not public', () => {
+    render(<DistrictCard district={{ ...mockDistrict, is_public: false }} />);
+    expect(screen.getByText('Private')).toBeInTheDocument();
+  });
+
+  it('renders admin link with correct subdomain URL for production', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'admin.stratadash.org',
+        port: '',
+        protocol: 'https:',
+        search: '',
+      },
+      writable: true,
+    });
+
+    render(<DistrictCard district={mockDistrict} />);
+
+    const adminLink = screen.getByTitle('Open district admin');
+    expect(adminLink).toHaveAttribute(
+      'href',
+      'https://westside.stratadash.org/admin'
+    );
+  });
+
+  it('renders logo when logo_url is provided', () => {
+    render(
+      <DistrictCard
+        district={{ ...mockDistrict, logo_url: 'https://example.com/logo.png' }}
+      />
+    );
+
+    // Logo has alt="" for decorative purposes, so query by tag
+    const logo = document.querySelector('img[src="https://example.com/logo.png"]');
+    expect(logo).toBeInTheDocument();
+  });
+
+  it('renders initial letter when no logo is provided', () => {
+    render(<DistrictCard district={mockDistrict} />);
+    expect(screen.getByText('W')).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/dashboard/__tests__/DistrictGridItem.test.tsx
+++ b/src/components/admin/dashboard/__tests__/DistrictGridItem.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DistrictGridItem } from '../DistrictGridItem';
+import type { DistrictWithStats } from '../../../../lib/services/systemAdmin.service';
+
+const mockDistrict: DistrictWithStats = {
+  id: '123',
+  name: 'Westside Community Schools',
+  slug: 'westside',
+  tagline: 'Community. Innovation. Excellence.',
+  is_public: true,
+  primary_color: '#C03537',
+  logo_url: undefined,
+  goals_count: 15,
+  schools_count: 0,
+  users_count: 1,
+};
+
+describe('DistrictGridItem', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Mock window.location for localhost
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'localhost',
+        port: '5173',
+        protocol: 'http:',
+        search: '?subdomain=admin',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('renders district name and stats', () => {
+    render(<DistrictGridItem district={mockDistrict} />);
+
+    expect(screen.getByText('Westside Community Schools')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument(); // goals
+    expect(screen.getByText('westside')).toBeInTheDocument(); // slug
+  });
+
+  it('renders admin link with correct subdomain URL for localhost', () => {
+    render(<DistrictGridItem district={mockDistrict} />);
+
+    const adminLink = screen.getByTitle('Open district admin');
+    expect(adminLink).toHaveAttribute(
+      'href',
+      'http://localhost:5173/admin?subdomain=westside'
+    );
+  });
+
+  it('renders public badge when district is public', () => {
+    render(<DistrictGridItem district={mockDistrict} />);
+    expect(screen.getByText('Public')).toBeInTheDocument();
+  });
+
+  it('renders private badge when district is not public', () => {
+    render(<DistrictGridItem district={{ ...mockDistrict, is_public: false }} />);
+    expect(screen.getByText('Private')).toBeInTheDocument();
+  });
+
+  it('renders admin link with correct subdomain URL for production', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'admin.stratadash.org',
+        port: '',
+        protocol: 'https:',
+        search: '',
+      },
+      writable: true,
+    });
+
+    render(<DistrictGridItem district={mockDistrict} />);
+
+    const adminLink = screen.getByTitle('Open district admin');
+    expect(adminLink).toHaveAttribute(
+      'href',
+      'https://westside.stratadash.org/admin'
+    );
+  });
+
+  it('renders logo when logo_url is provided', () => {
+    render(
+      <DistrictGridItem
+        district={{ ...mockDistrict, logo_url: 'https://example.com/logo.png' }}
+      />
+    );
+
+    // Logo has alt="" for decorative purposes, so query by tag
+    const logo = document.querySelector('img[src="https://example.com/logo.png"]');
+    expect(logo).toBeInTheDocument();
+  });
+
+  it('renders initial letter when no logo is provided', () => {
+    render(<DistrictGridItem district={mockDistrict} />);
+    expect(screen.getByText('W')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed district admin links on the system admin dashboard to use proper subdomain URLs
- Links were using relative paths (`/westside/admin`) which stayed on `admin.stratadash.org` and got caught by the catch-all redirect
- Now uses `buildSubdomainUrlWithPath()` to generate correct subdomain URLs (`westside.stratadash.org/admin`)

## Changes

- `src/components/admin/dashboard/DistrictCard.tsx` - Use subdomain URL for admin link
- `src/components/admin/dashboard/DistrictGridItem.tsx` - Use subdomain URL for admin link
- Added tests for both components verifying correct URL generation for localhost and production

## Test plan

- [x] All 287 tests pass (including 14 new tests)
- [x] Build passes
- [ ] Manual test: Navigate to `admin.stratadash.org`, click district admin link, verify it goes to `{district}.stratadash.org/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for dashboard components, including admin link generation, badge rendering, and logo display across different environments.

* **Refactor**
  * Updated internal admin URL construction to use a consistent subdomain-aware pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->