### PR TITLE
fix: remove unit concatenation from chart labels

### DIFF
--- a/e2e/admin/metric-visualization.spec.ts
+++ b/e2e/admin/metric-visualization.spec.ts
@@ -198,6 +198,30 @@ test.describe('Public Metric Visualization', () => {
   });
 });
 
+// Bar chart label tests - verify labels show value only, not concatenated units
+test.describe('Bar Chart Label Formatting', () => {
+  test('bar chart labels should display numeric values without unit concatenation', async ({ page }) => {
+    await page.goto('/westside/goals');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for canvas charts to render
+    const canvasElements = page.locator('canvas');
+    const count = await canvasElements.count();
+
+    if (count > 0) {
+      // Take a screenshot for visual verification that labels show clean values
+      // Labels should show "3.75" not "3.75rating" or "100score"
+      const firstCanvas = canvasElements.first();
+      await expect(firstCanvas).toBeVisible();
+
+      // Visual regression test - update baseline after fix is applied
+      await expect(firstCanvas).toHaveScreenshot('bar-chart-labels.png', {
+        maxDiffPixels: 100,
+      });
+    }
+  });
+});
+
 // Visual regression tests (optional, requires baseline screenshots)
 test.describe.skip('Metric Chart Visual Tests', () => {
   test('donut chart should match visual snapshot', async ({ page }) => {

--- a/e2e/public/metrics-display.spec.ts
+++ b/e2e/public/metrics-display.spec.ts
@@ -137,6 +137,49 @@ test.describe('Narrative Visualization Layout', () => {
   });
 });
 
+test.describe('Bar Chart Label Formatting - Public Site', () => {
+  test('expanded goal panel bar chart labels should display value only (no unit concatenation)', async ({ page }) => {
+    // Navigate to objective detail page which shows Goals Overview with expandable cards
+    await page.goto('/westside');
+    await page.waitForSelector('[data-testid^="objective-"]', { state: 'visible', timeout: 15000 });
+
+    // Click on Objective 1 to go to objective detail
+    const objective1 = page.locator('[data-testid="objective-1"]').first();
+    await objective1.click();
+    await page.waitForTimeout(500);
+
+    // Should be on objective detail page with Goals Overview
+    await expect(page).toHaveURL(/\/westside\/objective\//);
+
+    // Wait for goal cards to load
+    await page.waitForSelector('.rounded-xl.border', { state: 'visible', timeout: 10000 });
+
+    // Find and click on a goal card to expand it
+    const goalCards = page.locator('button.rounded-xl.border');
+    const cardCount = await goalCards.count();
+
+    if (cardCount > 0) {
+      await goalCards.first().click();
+      await page.waitForTimeout(500);
+
+      // Wait for canvas to render in expanded panel
+      const expandedPanel = page.locator('.border-2.shadow-lg').first();
+      if (await expandedPanel.isVisible()) {
+        const canvas = expandedPanel.locator('canvas');
+        if (await canvas.count() > 0) {
+          // Wait for chart to render
+          await page.waitForTimeout(300);
+
+          // Take screenshot for visual verification - labels should show "3.75" not "3.75rating"
+          await expect(canvas.first()).toHaveScreenshot('public-bar-chart-labels.png', {
+            maxDiffPixels: 100,
+          });
+        }
+      }
+    }
+  });
+});
+
 test.describe('Metrics Display', () => {
   test.beforeEach(async ({ page }) => {
     // Enable console logging for debugging

--- a/src/components/admin/MetricChartPreview.tsx
+++ b/src/components/admin/MetricChartPreview.tsx
@@ -329,7 +329,7 @@ export function MetricChartPreview({
         ctx.font = 'bold 11px Inter, sans-serif';
         ctx.textAlign = 'center';
         const barFormatted = formatValue(d.value);
-        ctx.fillText(barFormatted.value + barFormatted.unit, x + barWidth / 2, y - 6);
+        ctx.fillText(barFormatted.value, x + barWidth / 2, y - 6);
 
         // Label below bar
         ctx.fillStyle = '#6B7280';

--- a/src/components/public/ExpandedGoalPanel.tsx
+++ b/src/components/public/ExpandedGoalPanel.tsx
@@ -158,7 +158,7 @@ function MetricChart({ metric, chartColor }: { metric: Metric; chartColor: strin
   const chartType = vizConfig?.chartType || 'bar';
 
   // Format chart values using the centralized utility
-  const formatChartValue = (value: number): string => {
+  const formatChartValue = (value: number): { value: string; display: string } => {
     const result = formatMetricValueUtil({
       value,
       isPercentage: metric.is_percentage,
@@ -166,7 +166,7 @@ function MetricChart({ metric, chartColor }: { metric: Metric; chartColor: strin
       metricType: metric.metric_type,
       unit: metric.unit || '',
     });
-    return result.display;
+    return { value: result.value, display: result.display };
   };
 
   // Wait for parent layout animation to complete before rendering
@@ -293,7 +293,7 @@ function MetricChart({ metric, chartColor }: { metric: Metric; chartColor: strin
         ctx.fillStyle = '#059669';
         ctx.font = '11px Inter, sans-serif';
         ctx.textAlign = 'right';
-        ctx.fillText(`Target: ${formatChartValue(targetValue)}`, rect.width - padding.right, 14);
+        ctx.fillText(`Target: ${formatChartValue(targetValue).value}`, rect.width - padding.right, 14);
       }
 
       // Target line (dashed green)
@@ -354,7 +354,7 @@ function MetricChart({ metric, chartColor }: { metric: Metric; chartColor: strin
           ctx.fillStyle = '#374151';
           ctx.font = 'bold 11px Inter, sans-serif';
           ctx.textAlign = 'center';
-          ctx.fillText(formatChartValue(p.value), p.x, p.y - 10);
+          ctx.fillText(formatChartValue(p.value).value, p.x, p.y - 10);
 
           ctx.fillStyle = '#6B7280';
           ctx.font = '11px Inter, sans-serif';
@@ -376,7 +376,7 @@ function MetricChart({ metric, chartColor }: { metric: Metric; chartColor: strin
           ctx.fillStyle = '#374151';
           ctx.font = 'bold 11px Inter, sans-serif';
           ctx.textAlign = 'center';
-          ctx.fillText(formatChartValue(d.value), x + barWidth / 2, y - 6);
+          ctx.fillText(formatChartValue(d.value).value, x + barWidth / 2, y - 6);
 
           ctx.fillStyle = '#6B7280';
           ctx.font = '11px Inter, sans-serif';

--- a/src/components/public/GoalCardWithMetrics.tsx
+++ b/src/components/public/GoalCardWithMetrics.tsx
@@ -345,7 +345,7 @@ function CompactMetricCard({
         ctx.font = 'bold 10px Inter, sans-serif';
         ctx.textAlign = 'center';
         const barFormatted = formatValue(d.value);
-        ctx.fillText(barFormatted.value + barFormatted.unit, x + barWidth / 2, y - 4);
+        ctx.fillText(barFormatted.value, x + barWidth / 2, y - 4);
 
         ctx.fillStyle = '#6B7280';
         ctx.font = '9px Inter, sans-serif';

--- a/src/components/public/MetricCard.tsx
+++ b/src/components/public/MetricCard.tsx
@@ -422,7 +422,7 @@ export function MetricCard({ metric, index }: MetricCardProps) {
         ctx.font = 'bold 11px Inter, sans-serif';
         ctx.textAlign = 'center';
         const barFormatted = formatValue(d.value);
-        ctx.fillText(barFormatted.value + barFormatted.unit, x + barWidth / 2, y - 6);
+        ctx.fillText(barFormatted.value, x + barWidth / 2, y - 6);
 
         // Label below bar
         ctx.fillStyle = '#6B7280';

--- a/src/lib/utils/__tests__/formatMetricValue.test.ts
+++ b/src/lib/utils/__tests__/formatMetricValue.test.ts
@@ -177,6 +177,44 @@ describe('formatMetricValue', () => {
       expect(result.display).toBe('100 students');
     });
   });
+
+  describe('bar chart label formatting', () => {
+    it('provides value without unit for bar labels (rating type)', () => {
+      const result = formatMetricValue({
+        value: 3.75,
+        metricType: 'rating',
+        decimalPlaces: 2,
+        targetValue: 5.0,
+      });
+      // Bar labels should use only result.value, not value + unit
+      expect(result.value).toBe('3.75');
+      expect(result.value).not.toContain('rating');
+      expect(result.value).not.toContain('/');
+    });
+
+    it('provides value without unit for bar labels (percentage type)', () => {
+      const result = formatMetricValue({
+        value: 85,
+        isPercentage: true,
+        decimalPlaces: 0,
+      });
+      // Bar labels should use only result.value, not value + unit
+      expect(result.value).toBe('85');
+      expect(result.value).not.toContain('%');
+    });
+
+    it('provides value without unit for bar labels (custom unit)', () => {
+      const result = formatMetricValue({
+        value: 100,
+        isPercentage: false,
+        decimalPlaces: 0,
+        unit: 'score',
+      });
+      // Bar labels should use only result.value, not value + unit
+      expect(result.value).toBe('100');
+      expect(result.value).not.toContain('score');
+    });
+  });
 });
 
 describe('getNumberFormat', () => {


### PR DESCRIPTION
## Summary
- Fixed bar chart labels showing concatenated values like "3.75rating" instead of "3.75"
- Fixed target labels showing "Target: 3.50rating" instead of "Target: 3.50"
- Applied fix across admin and public site components

## Changes
- **MetricCard.tsx** - Bar labels now use `.value` only
- **MetricChartPreview.tsx** - Bar labels now use `.value` only
- **GoalCardWithMetrics.tsx** - Bar labels now use `.value` only
- **ExpandedGoalPanel.tsx** - Bar and target labels now use `.value` only

## Test plan
- [x] Unit tests added for bar label formatting behavior
- [x] E2E visual regression tests added for chart labels
- [ ] Manual verification: Navigate to /westside → expand goal cards → verify labels show clean numeric values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bar chart labels now display numeric values only, removing unit suffixes from visualizations across all chart components.

* **Tests**
  * Added test coverage for bar chart label formatting in admin and public interfaces to ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->