### PR TITLE
feat: add Privacy Policy and Terms of Service pages

### DIFF
--- a/src/pages/legal/PrivacyPage.tsx
+++ b/src/pages/legal/PrivacyPage.tsx
@@ -1,0 +1,145 @@
+import { Link } from 'react-router-dom';
+import { Target, ArrowLeft } from 'lucide-react';
+
+/**
+ * Privacy Policy page for stratadash.org
+ */
+export function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white via-neutral-50 to-white">
+      {/* Navigation */}
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="flex items-center gap-2">
+              <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center shadow-lg shadow-primary/20">
+                <Target className="w-6 h-6 text-white" />
+              </div>
+              <span className="text-2xl font-bold text-gray-900">StrataDash</span>
+            </Link>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 px-4 py-2 text-gray-600 hover:text-gray-900 transition-colors font-medium"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Home
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      {/* Content */}
+      <main className="container mx-auto px-6 pt-32 pb-20 max-w-4xl">
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-8">Privacy Policy</h1>
+        <p className="text-gray-500 mb-12">Last updated: January 2026</p>
+
+        <div className="prose prose-lg prose-gray max-w-none">
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Introduction</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              StrataDash ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our strategic planning platform.
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              Please read this privacy policy carefully. If you do not agree with the terms of this privacy policy, please do not access the platform.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Information We Collect</h2>
+            <h3 className="text-xl font-medium text-gray-800 mb-3">Personal Information</h3>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              We may collect personal information that you voluntarily provide to us when you register on the platform, including:
+            </p>
+            <ul className="list-disc list-inside text-gray-600 space-y-2 mb-6">
+              <li>Name and email address</li>
+              <li>Organization/district name</li>
+              <li>Job title and role</li>
+              <li>Contact information</li>
+            </ul>
+
+            <h3 className="text-xl font-medium text-gray-800 mb-3">Usage Data</h3>
+            <p className="text-gray-600 leading-relaxed">
+              We automatically collect certain information when you visit, use, or navigate the platform. This information may include device and usage information, such as your IP address, browser type, operating system, and pages visited.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">How We Use Your Information</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              We use the information we collect to:
+            </p>
+            <ul className="list-disc list-inside text-gray-600 space-y-2">
+              <li>Provide, operate, and maintain the platform</li>
+              <li>Improve, personalize, and expand our services</li>
+              <li>Understand and analyze how you use our platform</li>
+              <li>Communicate with you about updates and support</li>
+              <li>Process transactions and send related information</li>
+              <li>Protect against fraudulent or unauthorized activity</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Data Security</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We implement appropriate technical and organizational security measures to protect your personal information. However, no method of transmission over the Internet or electronic storage is 100% secure, and we cannot guarantee absolute security.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Data Retention</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We will retain your personal information only for as long as necessary to fulfill the purposes outlined in this privacy policy, unless a longer retention period is required by law.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Your Rights</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              Depending on your location, you may have the following rights regarding your personal information:
+            </p>
+            <ul className="list-disc list-inside text-gray-600 space-y-2">
+              <li>Right to access your personal data</li>
+              <li>Right to correct inaccurate data</li>
+              <li>Right to request deletion of your data</li>
+              <li>Right to restrict or object to processing</li>
+              <li>Right to data portability</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Contact Us</h2>
+            <p className="text-gray-600 leading-relaxed">
+              If you have questions or concerns about this Privacy Policy, please contact us at{' '}
+              <a href="mailto:privacy@stratadash.org" className="text-primary hover:underline">
+                privacy@stratadash.org
+              </a>
+            </p>
+          </section>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="container mx-auto px-6 py-12 border-t border-gray-100">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+              <Target className="w-5 h-5 text-white" />
+            </div>
+            <span className="text-lg font-semibold text-gray-900">StrataDash</span>
+          </div>
+          <div className="flex items-center gap-6 text-sm">
+            <Link to="/privacy" className="text-primary font-medium">
+              Privacy Policy
+            </Link>
+            <Link to="/terms" className="text-gray-500 hover:text-gray-700 transition-colors">
+              Terms of Service
+            </Link>
+          </div>
+          <p className="text-gray-400 text-sm">
+            &copy; {new Date().getFullYear()} StrataDash. All rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/legal/TermsPage.tsx
+++ b/src/pages/legal/TermsPage.tsx
@@ -1,0 +1,160 @@
+import { Link } from 'react-router-dom';
+import { Target, ArrowLeft } from 'lucide-react';
+
+/**
+ * Terms of Service page for stratadash.org
+ */
+export function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white via-neutral-50 to-white">
+      {/* Navigation */}
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="flex items-center gap-2">
+              <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center shadow-lg shadow-primary/20">
+                <Target className="w-6 h-6 text-white" />
+              </div>
+              <span className="text-2xl font-bold text-gray-900">StrataDash</span>
+            </Link>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 px-4 py-2 text-gray-600 hover:text-gray-900 transition-colors font-medium"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Home
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      {/* Content */}
+      <main className="container mx-auto px-6 pt-32 pb-20 max-w-4xl">
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-8">Terms of Service</h1>
+        <p className="text-gray-500 mb-12">Last updated: January 2026</p>
+
+        <div className="prose prose-lg prose-gray max-w-none">
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Agreement to Terms</h2>
+            <p className="text-gray-600 leading-relaxed">
+              By accessing or using StrataDash ("the Platform"), you agree to be bound by these Terms of Service. If you disagree with any part of these terms, you may not access the Platform.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Description of Service</h2>
+            <p className="text-gray-600 leading-relaxed">
+              StrataDash is a strategic planning platform designed for educational districts. The Platform provides tools for goal management, metrics tracking, progress visualization, and stakeholder communication.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">User Accounts</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              When you create an account with us, you must provide accurate, complete, and current information. You are responsible for:
+            </p>
+            <ul className="list-disc list-inside text-gray-600 space-y-2">
+              <li>Maintaining the confidentiality of your account credentials</li>
+              <li>All activities that occur under your account</li>
+              <li>Notifying us immediately of any unauthorized use</li>
+              <li>Ensuring your use complies with all applicable laws</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Acceptable Use</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              You agree not to use the Platform to:
+            </p>
+            <ul className="list-disc list-inside text-gray-600 space-y-2">
+              <li>Violate any applicable laws or regulations</li>
+              <li>Infringe upon the rights of others</li>
+              <li>Transmit harmful code, viruses, or malicious software</li>
+              <li>Attempt to gain unauthorized access to our systems</li>
+              <li>Interfere with or disrupt the Platform's operation</li>
+              <li>Collect or harvest user data without consent</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Intellectual Property</h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              The Platform and its original content, features, and functionality are owned by StrataDash and are protected by international copyright, trademark, and other intellectual property laws.
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              You retain ownership of any data you input into the Platform. By using the Platform, you grant us a license to use, store, and process your data solely for the purpose of providing our services.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Service Availability</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We strive to maintain high availability of the Platform but do not guarantee uninterrupted access. We may modify, suspend, or discontinue any aspect of the Platform at any time without prior notice.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Limitation of Liability</h2>
+            <p className="text-gray-600 leading-relaxed">
+              To the maximum extent permitted by law, StrataDash shall not be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of or inability to use the Platform.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Indemnification</h2>
+            <p className="text-gray-600 leading-relaxed">
+              You agree to indemnify and hold harmless StrataDash, its officers, directors, employees, and agents from any claims, damages, losses, or expenses arising from your use of the Platform or violation of these Terms.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Changes to Terms</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We reserve the right to modify these Terms at any time. We will notify users of any material changes by posting the new Terms on this page with an updated revision date. Your continued use of the Platform after such changes constitutes acceptance of the new Terms.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Governing Law</h2>
+            <p className="text-gray-600 leading-relaxed">
+              These Terms shall be governed by and construed in accordance with the laws of the United States, without regard to its conflict of law provisions.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Contact Us</h2>
+            <p className="text-gray-600 leading-relaxed">
+              If you have questions about these Terms of Service, please contact us at{' '}
+              <a href="mailto:legal@stratadash.org" className="text-primary hover:underline">
+                legal@stratadash.org
+              </a>
+            </p>
+          </section>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="container mx-auto px-6 py-12 border-t border-gray-100">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
+              <Target className="w-5 h-5 text-white" />
+            </div>
+            <span className="text-lg font-semibold text-gray-900">StrataDash</span>
+          </div>
+          <div className="flex items-center gap-6 text-sm">
+            <Link to="/privacy" className="text-gray-500 hover:text-gray-700 transition-colors">
+              Privacy Policy
+            </Link>
+            <Link to="/terms" className="text-primary font-medium">
+              Terms of Service
+            </Link>
+          </div>
+          <p className="text-gray-400 text-sm">
+            &copy; {new Date().getFullYear()} StrataDash. All rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/legal/index.ts
+++ b/src/pages/legal/index.ts
@@ -1,0 +1,2 @@
+export { PrivacyPage } from './PrivacyPage';
+export { TermsPage } from './TermsPage';

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -3,6 +3,7 @@ import { MarketingLanding } from '../pages/marketing/Landing';
 import { Login } from '../pages/Login';
 import { DistrictRedirect } from '../components/DistrictRedirect';
 import { AccountSettings } from '../pages/AccountSettings';
+import { PrivacyPage, TermsPage } from '../pages/legal';
 import { useAuth } from '../contexts/AuthContext';
 
 /**
@@ -36,6 +37,10 @@ export function RootRouter() {
       {/* Marketing pages */}
       <Route path="/" element={<MarketingLanding />} />
       <Route path="/login" element={<Login />} />
+
+      {/* Legal pages */}
+      <Route path="/privacy" element={<PrivacyPage />} />
+      <Route path="/terms" element={<TermsPage />} />
 
       {/* Protected routes */}
       <Route


### PR DESCRIPTION
## Summary
- Add Privacy Policy page (`/privacy`) with comprehensive privacy policy content
- Add Terms of Service page (`/terms`) with terms of service content
- Routes added to RootRouter for the root domain (stratadash.org)
- Styling matches existing marketing page design

## Changes
- `src/pages/legal/PrivacyPage.tsx` - Privacy Policy page component
- `src/pages/legal/TermsPage.tsx` - Terms of Service page component  
- `src/pages/legal/index.ts` - Barrel export
- `src/routers/RootRouter.tsx` - Added `/privacy` and `/terms` routes

## Test plan
- [ ] Visit `/privacy` on stratadash.org - should display Privacy Policy
- [ ] Visit `/terms` on stratadash.org - should display Terms of Service
- [ ] Footer links on district pages should navigate to these pages
- [ ] Back to Home link should return to landing page
- [ ] Responsive design works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Privacy Policy page with comprehensive information sections including data collection, usage, security, retention, and user rights.
  * Added Terms of Service page detailing service agreement, user accounts, acceptable use, intellectual property, and liability terms.
  * Both pages include navigation and footer with links to legal documents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->