### PR TITLE
feat: improve navigation and routing for logged-in users

### DIFF
--- a/src/components/common/UserAvatarMenu.tsx
+++ b/src/components/common/UserAvatarMenu.tsx
@@ -1,10 +1,17 @@
+import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Settings, LogOut, User, LayoutDashboard, ChevronDown } from 'lucide-react';
+import { Settings, LogOut, User, LayoutDashboard, ChevronDown, Building2, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Avatar } from '../ui/Avatar';
 import { cn } from '../../lib/utils';
 import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
+import { supabase } from '../../lib/supabase';
+
+interface AdminDistrict {
+  district_slug: string;
+  district_name: string;
+}
 
 interface UserAvatarMenuProps {
   className?: string;
@@ -22,8 +29,43 @@ interface UserAvatarMenuProps {
  * - Mobile responsive (hides username on small screens)
  */
 export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuProps) {
-  const { user, logout } = useAuth();
+  const { user, logout, isSystemAdmin } = useAuth();
   const navigate = useNavigate();
+  const [adminDistricts, setAdminDistricts] = useState<AdminDistrict[]>([]);
+
+  // Fetch user's admin districts
+  useEffect(() => {
+    async function fetchAdminDistricts() {
+      if (!user) return;
+
+      const { data, error } = await supabase
+        .from('spb_district_admins')
+        .select(`
+          district_slug,
+          spb_districts!inner(name)
+        `)
+        .eq('user_id', user.id);
+
+      if (error) {
+        console.error('Failed to fetch admin districts:', error);
+        return;
+      }
+
+      if (data) {
+        const districts = data.map((d) => {
+          // The join returns spb_districts as an object with name property
+          const districtData = d.spb_districts as unknown as { name: string } | null;
+          return {
+            district_slug: d.district_slug,
+            district_name: districtData?.name || d.district_slug,
+          };
+        });
+        setAdminDistricts(districts);
+      }
+    }
+
+    fetchAdminDistricts();
+  }, [user]);
 
   // Get display name from user metadata or fall back to email
   const displayName =
@@ -39,6 +81,9 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
       console.error('Logout failed:', error);
     }
   };
+
+  // Determine if user has any admin access
+  const hasAdminAccess = isSystemAdmin || adminDistricts.length > 0;
 
   return (
     <DropdownMenu.Root>
@@ -84,6 +129,16 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
           <div className="py-1">
             <DropdownMenu.Item asChild>
               <Link
+                to="/dashboard"
+                className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
+              >
+                <LayoutDashboard className="w-4 h-4 text-indigo-500" />
+                Dashboard
+              </Link>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Item asChild>
+              <Link
                 to="/account"
                 className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
               >
@@ -101,17 +156,45 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
                 Settings
               </Link>
             </DropdownMenu.Item>
-
-            <DropdownMenu.Item asChild>
-              <a
-                href={buildSubdomainUrlWithPath('admin')}
-                className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
-              >
-                <LayoutDashboard className="w-4 h-4 text-amber-600" />
-                Admin
-              </a>
-            </DropdownMenu.Item>
           </div>
+
+          {/* Admin Section - Only shown if user has admin access */}
+          {hasAdminAccess && (
+            <>
+              <DropdownMenu.Separator className="h-px bg-slate-100 my-1" />
+              <div className="py-1">
+                <div className="px-4 py-1.5 text-[11px] font-semibold text-slate-400 uppercase tracking-wider">
+                  Admin
+                </div>
+
+                {/* System Admin link - only for system admins */}
+                {isSystemAdmin && (
+                  <DropdownMenu.Item asChild>
+                    <a
+                      href={buildSubdomainUrlWithPath('admin')}
+                      className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
+                    >
+                      <Shield className="w-4 h-4 text-amber-600" />
+                      System Admin
+                    </a>
+                  </DropdownMenu.Item>
+                )}
+
+                {/* District admin links */}
+                {adminDistricts.map((district) => (
+                  <DropdownMenu.Item key={district.district_slug} asChild>
+                    <a
+                      href={buildSubdomainUrlWithPath('district', '/admin', district.district_slug)}
+                      className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
+                    >
+                      <Building2 className="w-4 h-4 text-indigo-500" />
+                      {district.district_name}
+                    </a>
+                  </DropdownMenu.Item>
+                ))}
+              </div>
+            </>
+          )}
 
           {/* Sign Out */}
           <DropdownMenu.Separator className="h-px bg-slate-100 my-1" />

--- a/src/components/common/UserAvatarMenu.tsx
+++ b/src/components/common/UserAvatarMenu.tsx
@@ -143,13 +143,23 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
           {/* Navigation Items */}
           <div className="py-1">
             <DropdownMenu.Item asChild>
-              <a
-                href={dashboardUrl}
-                className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
-              >
-                <LayoutDashboard className="w-4 h-4 text-indigo-500" />
-                Dashboard
-              </a>
+              {subdomainType === 'root' ? (
+                <Link
+                  to="/dashboard"
+                  className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
+                >
+                  <LayoutDashboard className="w-4 h-4 text-indigo-500" />
+                  Dashboard
+                </Link>
+              ) : (
+                <a
+                  href={dashboardUrl}
+                  className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
+                >
+                  <LayoutDashboard className="w-4 h-4 text-indigo-500" />
+                  Dashboard
+                </a>
+              )}
             </DropdownMenu.Item>
 
             <DropdownMenu.Item asChild>

--- a/src/components/common/UserAvatarMenu.tsx
+++ b/src/components/common/UserAvatarMenu.tsx
@@ -3,9 +3,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Settings, LogOut, User, LayoutDashboard, ChevronDown, Building2, Shield } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useSubdomain } from '../../contexts/SubdomainContext';
 import { Avatar } from '../ui/Avatar';
 import { cn } from '../../lib/utils';
-import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
+import { buildSubdomainUrlWithPath, getSubdomainUrl } from '../../lib/subdomain';
 import { supabase } from '../../lib/supabase';
 
 interface AdminDistrict {
@@ -30,37 +31,51 @@ interface UserAvatarMenuProps {
  */
 export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuProps) {
   const { user, logout, isSystemAdmin } = useAuth();
+  const { type: subdomainType } = useSubdomain();
   const navigate = useNavigate();
   const [adminDistricts, setAdminDistricts] = useState<AdminDistrict[]>([]);
+  const [loadingDistricts, setLoadingDistricts] = useState(true);
+
+  // Build dashboard URL - use absolute URL on non-root subdomains
+  const dashboardUrl = subdomainType === 'root'
+    ? '/dashboard'
+    : getSubdomainUrl('root') + '/dashboard';
 
   // Fetch user's admin districts
   useEffect(() => {
     async function fetchAdminDistricts() {
-      if (!user) return;
-
-      const { data, error } = await supabase
-        .from('spb_district_admins')
-        .select(`
-          district_slug,
-          spb_districts!inner(name)
-        `)
-        .eq('user_id', user.id);
-
-      if (error) {
-        console.error('Failed to fetch admin districts:', error);
+      if (!user) {
+        setLoadingDistricts(false);
         return;
       }
 
-      if (data) {
-        const districts = data.map((d) => {
-          // The join returns spb_districts as an object with name property
-          const districtData = d.spb_districts as unknown as { name: string } | null;
-          return {
-            district_slug: d.district_slug,
-            district_name: districtData?.name || d.district_slug,
-          };
-        });
-        setAdminDistricts(districts);
+      try {
+        const { data, error } = await supabase
+          .from('spb_district_admins')
+          .select(`
+            district_slug,
+            spb_districts!inner(name)
+          `)
+          .eq('user_id', user.id);
+
+        if (error) {
+          console.error('Failed to fetch admin districts:', error);
+          return;
+        }
+
+        if (data) {
+          const districts = data.map((d) => {
+            // The join returns spb_districts as an object with name property
+            const districtData = d.spb_districts as unknown as { name: string } | null;
+            return {
+              district_slug: d.district_slug,
+              district_name: districtData?.name || d.district_slug,
+            };
+          });
+          setAdminDistricts(districts);
+        }
+      } finally {
+        setLoadingDistricts(false);
       }
     }
 
@@ -128,13 +143,13 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
           {/* Navigation Items */}
           <div className="py-1">
             <DropdownMenu.Item asChild>
-              <Link
-                to="/dashboard"
+              <a
+                href={dashboardUrl}
                 className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 focus:bg-slate-50 outline-none cursor-pointer transition-colors"
               >
                 <LayoutDashboard className="w-4 h-4 text-indigo-500" />
                 Dashboard
-              </Link>
+              </a>
             </DropdownMenu.Item>
 
             <DropdownMenu.Item asChild>
@@ -158,8 +173,8 @@ export function UserAvatarMenu({ className, showName = true }: UserAvatarMenuPro
             </DropdownMenu.Item>
           </div>
 
-          {/* Admin Section - Only shown if user has admin access */}
-          {hasAdminAccess && (
+          {/* Admin Section - Only shown if user has admin access and districts loaded */}
+          {!loadingDistricts && hasAdminAccess && (
             <>
               <DropdownMenu.Separator className="h-px bg-slate-100 my-1" />
               <div className="py-1">

--- a/src/components/common/__tests__/UserAvatarMenu.test.tsx
+++ b/src/components/common/__tests__/UserAvatarMenu.test.tsx
@@ -12,6 +12,11 @@ vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+// Mock SubdomainContext - default to root subdomain
+vi.mock('../../../contexts/SubdomainContext', () => ({
+  useSubdomain: () => ({ type: 'root', slug: null }),
+}));
+
 // Mock subdomain utility
 vi.mock('../../../lib/subdomain', () => ({
   buildSubdomainUrlWithPath: (type: string, path?: string, slug?: string) => {
@@ -19,14 +24,20 @@ vi.mock('../../../lib/subdomain', () => ({
     if (type === 'district' && slug) return `http://localhost:5173?subdomain=${slug}${path || ''}`;
     return 'http://localhost:5173';
   },
+  getSubdomainUrl: (type: string) => {
+    if (type === 'root') return 'http://localhost:5173';
+    if (type === 'admin') return 'http://localhost:5173?subdomain=admin';
+    return 'http://localhost:5173';
+  },
 }));
 
-// Mock Supabase
+// Mock Supabase - default returns empty districts
+const mockSupabaseResponse = vi.fn().mockResolvedValue({ data: [], error: null });
 vi.mock('../../../lib/supabase', () => ({
   supabase: {
     from: () => ({
       select: () => ({
-        eq: () => Promise.resolve({ data: [], error: null }),
+        eq: () => mockSupabaseResponse(),
       }),
     }),
   },
@@ -41,6 +52,7 @@ describe('UserAvatarMenu', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLogout.mockResolvedValue(undefined);
+    mockSupabaseResponse.mockResolvedValue({ data: [], error: null });
   });
 
   describe('when user is not authenticated', () => {
@@ -142,6 +154,40 @@ describe('UserAvatarMenu', () => {
         const adminLink = screen.getByText('System Admin').closest('a');
         expect(adminLink).toHaveAttribute('href', 'http://localhost:5173?subdomain=admin');
       });
+    });
+
+    it('shows district admin links when user has district access', async () => {
+      mockSupabaseResponse.mockResolvedValue({
+        data: [
+          {
+            district_slug: 'westside',
+            spb_districts: { name: 'Westside District' },
+          },
+        ],
+        error: null,
+      });
+
+      mockUseAuth.mockReturnValue({
+        user: mockUser,
+        logout: mockLogout,
+        isSystemAdmin: false,
+      });
+
+      const user = userEvent.setup();
+      renderWithRouter(<UserAvatarMenu />);
+
+      await user.click(screen.getByRole('button', { name: /user menu/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Westside District')).toBeInTheDocument();
+      });
+
+      // Verify the link uses subdomain-aware URL
+      const districtLink = screen.getByText('Westside District').closest('a');
+      expect(districtLink).toHaveAttribute(
+        'href',
+        'http://localhost:5173?subdomain=westside/admin'
+      );
     });
 
     it('calls logout when Sign Out is clicked', async () => {

--- a/src/components/common/__tests__/UserAvatarMenu.test.tsx
+++ b/src/components/common/__tests__/UserAvatarMenu.test.tsx
@@ -14,9 +14,21 @@ vi.mock('../../../contexts/AuthContext', () => ({
 
 // Mock subdomain utility
 vi.mock('../../../lib/subdomain', () => ({
-  buildSubdomainUrlWithPath: (type: string) => {
+  buildSubdomainUrlWithPath: (type: string, path?: string, slug?: string) => {
     if (type === 'admin') return 'http://localhost:5173?subdomain=admin';
+    if (type === 'district' && slug) return `http://localhost:5173?subdomain=${slug}${path || ''}`;
     return 'http://localhost:5173';
+  },
+}));
+
+// Mock Supabase
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
   },
 }));
 
@@ -36,6 +48,7 @@ describe('UserAvatarMenu', () => {
       mockUseAuth.mockReturnValue({
         user: null,
         logout: mockLogout,
+        isSystemAdmin: false,
       });
 
       const { container } = renderWithRouter(<UserAvatarMenu />);
@@ -56,6 +69,7 @@ describe('UserAvatarMenu', () => {
       mockUseAuth.mockReturnValue({
         user: mockUser,
         logout: mockLogout,
+        isSystemAdmin: false,
       });
     });
 
@@ -77,9 +91,9 @@ describe('UserAvatarMenu', () => {
       await user.click(triggerButton);
 
       await waitFor(() => {
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
         expect(screen.getByText('My Profile')).toBeInTheDocument();
         expect(screen.getByText('Settings')).toBeInTheDocument();
-        expect(screen.getByText('Admin')).toBeInTheDocument();
         expect(screen.getByText('Sign Out')).toBeInTheDocument();
       });
     });
@@ -95,25 +109,37 @@ describe('UserAvatarMenu', () => {
       });
     });
 
-    it('shows Admin link for all authenticated users', async () => {
+    it('shows System Admin link for system admins', async () => {
+      mockUseAuth.mockReturnValue({
+        user: mockUser,
+        logout: mockLogout,
+        isSystemAdmin: true,
+      });
+
       const user = userEvent.setup();
       renderWithRouter(<UserAvatarMenu />);
 
       await user.click(screen.getByRole('button', { name: /user menu/i }));
 
       await waitFor(() => {
-        expect(screen.getByText('Admin')).toBeInTheDocument();
+        expect(screen.getByText('System Admin')).toBeInTheDocument();
       });
     });
 
-    it('Admin link uses subdomain-aware URL', async () => {
+    it('System Admin link uses subdomain-aware URL', async () => {
+      mockUseAuth.mockReturnValue({
+        user: mockUser,
+        logout: mockLogout,
+        isSystemAdmin: true,
+      });
+
       const user = userEvent.setup();
       renderWithRouter(<UserAvatarMenu />);
 
       await user.click(screen.getByRole('button', { name: /user menu/i }));
 
       await waitFor(() => {
-        const adminLink = screen.getByText('Admin').closest('a');
+        const adminLink = screen.getByText('System Admin').closest('a');
         expect(adminLink).toHaveAttribute('href', 'http://localhost:5173?subdomain=admin');
       });
     });
@@ -143,6 +169,7 @@ describe('UserAvatarMenu', () => {
           user_metadata: {},
         },
         logout: mockLogout,
+        isSystemAdmin: false,
       });
 
       renderWithRouter(<UserAvatarMenu />);
@@ -159,6 +186,7 @@ describe('UserAvatarMenu', () => {
           user_metadata: { display_name: 'Test User' },
         },
         logout: mockLogout,
+        isSystemAdmin: false,
       });
     });
 
@@ -209,6 +237,7 @@ describe('UserAvatarMenu', () => {
           user_metadata: { display_name: 'Test' },
         },
         logout: mockLogout,
+        isSystemAdmin: false,
       });
     });
 

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -1,11 +1,15 @@
 import { Link } from 'react-router-dom';
 import { Icon } from '@iconify/react';
+import { useAuth } from '../../contexts/AuthContext';
+import { UserAvatarMenu } from '../common/UserAvatarMenu';
 
 interface MarketingNavProps {
   onDemoClick: () => void;
 }
 
 export function MarketingNav({ onDemoClick }: MarketingNavProps) {
+  const { isAuthenticated, loading } = useAuth();
+
   return (
     <nav className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-md border-b border-indigo-100">
       <div className="flex h-20 max-w-7xl mx-auto px-6 items-center justify-between">
@@ -53,18 +57,34 @@ export function MarketingNav({ onDemoClick }: MarketingNavProps) {
 
         {/* Actions */}
         <div className="flex items-center gap-4">
-          <Link
-            to="/login"
-            className="hidden sm:block text-sm font-medium text-indigo-600 hover:text-indigo-900 transition-colors"
-          >
-            Log in
-          </Link>
-          <button
-            onClick={onDemoClick}
-            className="bg-indigo-900 hover:bg-indigo-800 text-white text-sm font-medium px-4 py-2 rounded-lg shadow-sm transition-all hover:shadow-md hover:shadow-indigo-200"
-          >
-            View District Plan Demo
-          </button>
+          {loading ? (
+            <div className="w-8 h-8 rounded-full bg-indigo-100 animate-pulse" />
+          ) : isAuthenticated ? (
+            <>
+              <Link
+                to="/dashboard"
+                className="hidden sm:block text-sm font-medium text-indigo-600 hover:text-indigo-900 transition-colors"
+              >
+                Dashboard
+              </Link>
+              <UserAvatarMenu />
+            </>
+          ) : (
+            <>
+              <Link
+                to="/login"
+                className="hidden sm:block text-sm font-medium text-indigo-600 hover:text-indigo-900 transition-colors"
+              >
+                Log in
+              </Link>
+              <button
+                onClick={onDemoClick}
+                className="bg-indigo-900 hover:bg-indigo-800 text-white text-sm font-medium px-4 py-2 rounded-lg shadow-sm transition-all hover:shadow-md hover:shadow-indigo-200"
+              >
+                View District Plan Demo
+              </button>
+            </>
+          )}
         </div>
       </div>
     </nav>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -24,8 +24,8 @@ export function Login() {
   // Redirect if already authenticated
   useEffect(() => {
     if (isAuthenticated) {
-      const from = (location.state as LocationState)?.from || '/';
-      const redirectUrl = from + location.search;
+      const from = (location.state as LocationState)?.from;
+      const redirectUrl = from ? from + location.search : '/dashboard';
       navigate(redirectUrl, { replace: true });
     }
   }, [isAuthenticated, location.state, location.search, navigate]);
@@ -59,6 +59,7 @@ export function Login() {
         user.user_metadata?.role === 'system_admin' ||
         user.app_metadata?.role === 'system_admin';
 
+      // On admin subdomain, system admins stay, others go to root
       if (subdomainType === 'admin') {
         if (isSystemAdmin) {
           navigate(`/${location.search}`, { replace: true });
@@ -68,19 +69,10 @@ export function Login() {
         return;
       }
 
-      const { data: districtAdmin } = await supabase
-        .from('spb_district_admins')
-        .select('district_slug')
-        .eq('user_id', user.id)
-        .maybeSingle();
-
-      if (districtAdmin?.district_slug) {
-        navigate(`/${districtAdmin.district_slug}/admin${location.search}`, { replace: true });
-        return;
-      }
-
-      const from = (location.state as LocationState)?.from || '/';
-      const redirectUrl = from + location.search;
+      // Redirect to the intended destination or /dashboard
+      // Users can access admin pages from the avatar menu
+      const from = (location.state as LocationState)?.from;
+      const redirectUrl = from ? from + location.search : '/dashboard';
       navigate(redirectUrl, { replace: true });
     } catch (err) {
       console.error('[Login] Error:', err);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -25,10 +25,17 @@ export function Login() {
   useEffect(() => {
     if (isAuthenticated) {
       const from = (location.state as LocationState)?.from;
+
+      // On non-root subdomains, redirect to root domain dashboard
+      if (subdomainType !== 'root' && !from) {
+        window.location.href = getSubdomainUrl('root') + '/dashboard';
+        return;
+      }
+
       const redirectUrl = from ? from + location.search : '/dashboard';
       navigate(redirectUrl, { replace: true });
     }
-  }, [isAuthenticated, location.state, location.search, navigate]);
+  }, [isAuthenticated, location.state, location.search, navigate, subdomainType]);
 
   // Show nothing while redirecting
   if (isAuthenticated) {
@@ -72,6 +79,13 @@ export function Login() {
       // Redirect to the intended destination or /dashboard
       // Users can access admin pages from the avatar menu
       const from = (location.state as LocationState)?.from;
+
+      // On non-root subdomains (district), redirect to root domain dashboard
+      if (subdomainType !== 'root' && !from) {
+        window.location.href = getSubdomainUrl('root') + '/dashboard';
+        return;
+      }
+
       const redirectUrl = from ? from + location.search : '/dashboard';
       navigate(redirectUrl, { replace: true });
     } catch (err) {

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -30,35 +30,26 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * HomeRoute - Shows dashboard for authenticated users, marketing page for visitors
- */
-function HomeRoute() {
-  const { isAuthenticated, loading } = useAuth();
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[#F8FAFC]">
-        <div className="animate-spin w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full" />
-      </div>
-    );
-  }
-
-  if (isAuthenticated) {
-    return <DashboardLayout />;
-  }
-
-  return <MarketingLanding />;
-}
-
-/**
  * Router for the root domain (stratadash.org)
- * Handles marketing pages, authenticated dashboard, and redirects legacy district paths to subdomains.
+ * - Marketing landing page at / (always visible, logged in or not)
+ * - User dashboard at /dashboard (requires authentication)
+ * - Redirects legacy district paths to subdomains
  */
 export function RootRouter() {
   return (
     <Routes>
-      {/* Home - Dashboard for authenticated users, Marketing for visitors */}
-      <Route path="/" element={<HomeRoute />}>
+      {/* Marketing landing page - always visible */}
+      <Route path="/" element={<MarketingLanding />} />
+
+      {/* Dashboard - requires authentication */}
+      <Route
+        path="/dashboard"
+        element={
+          <RequireAuth>
+            <DashboardLayout basePath="/dashboard" />
+          </RequireAuth>
+        }
+      >
         <Route index element={<UserDashboard />} />
         <Route path="plans" element={<PlaceholderPage title="Strategic Plans" description="View and manage all your strategic plans in one place." />} />
         <Route path="plans/new" element={<PlaceholderPage title="Create New Plan" description="Create a new strategic plan for your organization." />} />


### PR DESCRIPTION
## Summary

- Marketing landing page now always visible at `/` whether logged in or not
- User dashboard moved to `/dashboard` route (protected with RequireAuth)
- MarketingNav shows avatar menu with Dashboard link when authenticated
- UserAvatarMenu enhanced with dynamic admin links based on user's access

## Changes

| File | Change |
|------|--------|
| `RootRouter.tsx` | Removed HomeRoute conditional, added `/dashboard` route |
| `MarketingNav.tsx` | Added auth awareness, shows avatar when logged in |
| `UserAvatarMenu.tsx` | Added Dashboard link, System Admin link, dynamic district admin links |
| `Login.tsx` | Changed post-login redirect to `/dashboard` |

## Test plan

- [ ] Anonymous user at `/` sees marketing page with "Log in" button
- [ ] Logged-in user at `/` sees marketing page with avatar menu + "Dashboard" link
- [ ] Logged-in user clicks Dashboard and goes to `/dashboard`
- [ ] District admin clicks avatar and sees their district(s) in dropdown
- [ ] System admin clicks avatar and sees "System Admin" link
- [ ] Clicking district admin link navigates to correct subdomain
- [ ] User logs out and returns to marketing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin section in the user menu showing system and district admin links.
  * Dashboard entry surfaced in the header/user menu with subdomain-aware behavior.
  * Actions area now conditionally shows loading, Dashboard, or Log in states based on auth.

* **Improvements**
  * Post-login redirect logic updated to prefer origin path or dashboard with subdomain-aware handling.
  * Routing adjusted: marketing remains at root and /dashboard is a protected route for authenticated users.

* **Tests**
  * Expanded tests covering admin roles and subdomain-aware links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->