### PR TITLE
fix: correct basePath for root domain dashboard navigation

### DIFF
--- a/src/pages/dashboard/UserDashboard.tsx
+++ b/src/pages/dashboard/UserDashboard.tsx
@@ -12,7 +12,7 @@ export function UserDashboard() {
 
   // Detect if we're in district admin context
   const isDistrictAdmin = location.pathname.startsWith('/admin');
-  const basePath = isDistrictAdmin ? '/admin' : '';
+  const basePath = isDistrictAdmin ? '/admin' : '/dashboard';
 
   // Fetch plans
   const { data: plans = [], isLoading: plansLoading } = useUserPlansWithCounts();


### PR DESCRIPTION
## Summary
- Fixed navigation bug where clicking on plans from the root domain dashboard redirected to `plans.stratadash.org` instead of staying on the current domain
- Root cause: `basePath` was set to empty string `''` instead of `/dashboard` for non-district-admin context, causing navigation to `/plans/...` which triggered the `/:slug/*` catch-all route

## Changes
- `src/pages/dashboard/UserDashboard.tsx`: Changed `basePath` from `''` to `'/dashboard'` when not in district admin context

## Test plan
- [ ] Navigate to `stratadash.org/dashboard` while logged in
- [ ] Click on "Strategic plans" in the sidebar
- [ ] Verify it navigates to `/dashboard/plans` (not `plans.stratadash.org`)
- [ ] Click "Create plan" and verify navigation stays on the domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation routing for non-admin users. Plan-related features are now accessed through the dashboard path structure, providing clearer URL organization for standard users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->