### PR TITLE
feat: display level 2 sub-goals on public and admin objective pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ npm run preview          # Preview production build
 ```
 
 > **Note for AI agents:** Use `npm run test:run` (single run) instead of `npm test` (watch mode) to avoid spawning multiple background processes.
+>
+> **CRITICAL:** Never pipe test commands through `head`, `tail`, or other truncating commands (e.g., `npm run test:run | head -100`). This kills the parent process while leaving vitest worker processes orphaned, causing memory exhaustion that can crash the system. Always let test commands run to completion.
 
 ### Quality checks
 

--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -56,8 +56,10 @@ export function ContactModal({ isOpen, onClose }: ContactModalProps) {
 
   // Reset form when modal closes
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     if (!isOpen) {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         setFormData({
           email: '',
           firstName: '',
@@ -71,6 +73,12 @@ export function ContactModal({ isOpen, onClose }: ContactModalProps) {
         setError(null);
       }, 300);
     }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [isOpen]);
 
   const handleChange = (

--- a/src/components/public/ExpandedGoalPanel.tsx
+++ b/src/components/public/ExpandedGoalPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Minimize2 } from 'lucide-react';
-import type { Goal, Metric } from '../../lib/types';
+import type { Goal, Metric, HierarchicalGoal } from '../../lib/types';
 import { calculateStatus } from './StatusBadge';
 import type { StatusType } from './StatusBadge';
 import { useMetricChartData } from '../../hooks/useMetrics';
@@ -32,6 +32,7 @@ interface ExpandedGoalPanelProps {
   metrics: Metric[];
   colorClass: string;
   onClose: () => void;
+  subGoals?: HierarchicalGoal[];
 }
 
 // Chart colors matching the design
@@ -441,6 +442,7 @@ export function ExpandedGoalPanel({
   metrics,
   colorClass,
   onClose,
+  subGoals,
 }: ExpandedGoalPanelProps) {
   const status = getManualStatus(goal);
   const primaryMetric = getPrimaryMetric(metrics, goal.id);
@@ -591,6 +593,41 @@ export function ExpandedGoalPanel({
             )}
           </div>
         </>
+      )}
+
+      {/* Sub-Goals Section */}
+      {subGoals && subGoals.length > 0 && (
+        <div className="px-6 pb-6 pt-2 border-t border-gray-100 dark:border-slate-800">
+          <h4 className="text-xs font-medium tracking-wider text-gray-400 dark:text-gray-500 uppercase mb-3">
+            Sub-Goals ({subGoals.length})
+          </h4>
+          <div className="space-y-2">
+            {subGoals.map((subGoal) => {
+              const subGoalStatus = getManualStatus(subGoal);
+              return (
+                <div
+                  key={subGoal.id}
+                  className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-slate-800 rounded-lg"
+                >
+                  <div className={`w-8 h-8 flex-shrink-0 rounded-lg ${colorClass} text-white flex items-center justify-center text-xs font-bold`}>
+                    {subGoal.goal_number}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {subGoal.title}
+                    </p>
+                    {subGoal.description && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {subGoal.description}
+                      </p>
+                    )}
+                  </div>
+                  <FilledStatusBadge status={subGoalStatus} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
       )}
     </motion.div>
   );

--- a/src/components/public/GoalsOverviewGrid.tsx
+++ b/src/components/public/GoalsOverviewGrid.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
-import type { Goal, Metric } from '../../lib/types';
+import type { Metric, HierarchicalGoal } from '../../lib/types';
 import { CompactGoalSummaryCard } from './CompactGoalSummaryCard';
 import { ExpandedGoalPanel } from './ExpandedGoalPanel';
 
 interface GoalsOverviewGridProps {
-  goals: Goal[];
+  goals: HierarchicalGoal[];
   metrics: Metric[];
   colorClass: string;
   isMobile: boolean;
@@ -80,6 +80,7 @@ export function GoalsOverviewGrid({
                     metrics={metrics}
                     colorClass={colorClass}
                     onClose={handleClose}
+                    subGoals={goal.children || []}
                   />
                 ) : (
                   <CompactGoalSummaryCard

--- a/src/components/public/__tests__/ExpandedGoalChart.integration.test.tsx
+++ b/src/components/public/__tests__/ExpandedGoalChart.integration.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '../../../test/setup';
 import { GoalsOverviewGrid } from '../GoalsOverviewGrid';
-import type { Goal, Metric } from '../../../lib/types';
+import type { HierarchicalGoal, Metric } from '../../../lib/types';
 
 // Mock Supabase client to avoid env var errors
 vi.mock('../../../lib/supabase', () => ({
@@ -62,7 +62,7 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
 Element.prototype.scrollIntoView = vi.fn();
 
 // Mock goals
-const mockGoals: Goal[] = [
+const mockGoals: HierarchicalGoal[] = [
   {
     id: 'goal-1',
     district_id: 'district-1',
@@ -76,6 +76,7 @@ const mockGoals: Goal[] = [
     order_position: 0,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
   {
     id: 'goal-2',
@@ -90,6 +91,7 @@ const mockGoals: Goal[] = [
     order_position: 1,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
   {
     id: 'goal-3',
@@ -104,6 +106,7 @@ const mockGoals: Goal[] = [
     order_position: 2,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
 ];
 

--- a/src/components/public/__tests__/ExpandedGoalPanel.test.tsx
+++ b/src/components/public/__tests__/ExpandedGoalPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '../../../test/setup';
 import { ExpandedGoalPanel } from '../ExpandedGoalPanel';
-import type { Goal, Metric } from '../../../lib/types';
+import type { Goal, Metric, HierarchicalGoal } from '../../../lib/types';
 
 // Mock Supabase client to avoid env var errors
 vi.mock('../../../lib/supabase', () => ({
@@ -577,6 +577,129 @@ describe('ExpandedGoalPanel', () => {
         expect(narrativeContainer).not.toHaveClass('h-[180px]');
         expect(narrativeContainer).not.toHaveClass('overflow-y-auto');
       }
+    });
+  });
+
+  describe('Sub-Goals Section', () => {
+    const mockSubGoals: HierarchicalGoal[] = [
+      {
+        id: 'subgoal-1',
+        district_id: 'district-1',
+        title: 'K-2 Reading Foundation',
+        description: 'Build strong phonics skills',
+        goal_number: '1.2.1',
+        level: 2,
+        parent_id: 'goal-1',
+        indicator_text: 'on-target',
+        order_position: 0,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        children: [],
+      },
+      {
+        id: 'subgoal-2',
+        district_id: 'district-1',
+        title: 'Grade 3-5 Comprehension',
+        description: 'Improve reading comprehension',
+        goal_number: '1.2.2',
+        level: 2,
+        parent_id: 'goal-1',
+        indicator_text: 'needs-attention',
+        order_position: 1,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        children: [],
+      },
+    ];
+
+    it('renders sub-goals section when subGoals prop is provided', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+          subGoals={mockSubGoals}
+        />
+      );
+
+      expect(screen.getByText('Sub-Goals (2)')).toBeInTheDocument();
+    });
+
+    it('renders each sub-goal with title and number', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+          subGoals={mockSubGoals}
+        />
+      );
+
+      expect(screen.getByText('K-2 Reading Foundation')).toBeInTheDocument();
+      expect(screen.getByText('Grade 3-5 Comprehension')).toBeInTheDocument();
+      expect(screen.getByText('1.2.1')).toBeInTheDocument();
+      expect(screen.getByText('1.2.2')).toBeInTheDocument();
+    });
+
+    it('renders sub-goal descriptions', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+          subGoals={mockSubGoals}
+        />
+      );
+
+      expect(screen.getByText('Build strong phonics skills')).toBeInTheDocument();
+      expect(screen.getByText('Improve reading comprehension')).toBeInTheDocument();
+    });
+
+    it('renders status badges for each sub-goal', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+          subGoals={mockSubGoals}
+        />
+      );
+
+      // Two "On Target" badges: one for the goal metric, one for the sub-goal
+      const onTargetBadges = screen.getAllByText('On Target');
+      expect(onTargetBadges.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText('Needs Attention')).toBeInTheDocument();
+    });
+
+    it('does not render sub-goals section when subGoals is empty', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+          subGoals={[]}
+        />
+      );
+
+      expect(screen.queryByText(/Sub-Goals/)).not.toBeInTheDocument();
+    });
+
+    it('does not render sub-goals section when subGoals is undefined', () => {
+      render(
+        <ExpandedGoalPanel
+          goal={mockGoal}
+          metrics={[mockMetric]}
+          colorClass="bg-district-red"
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.queryByText(/Sub-Goals/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/public/__tests__/GoalsOverviewGrid.test.tsx
+++ b/src/components/public/__tests__/GoalsOverviewGrid.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '../../../test/setup';
 import { GoalsOverviewGrid } from '../GoalsOverviewGrid';
-import type { Goal, Metric } from '../../../lib/types';
+import type { HierarchicalGoal, Metric } from '../../../lib/types';
 
 // Mock Supabase client to avoid env var errors
 vi.mock('../../../lib/supabase', () => ({
@@ -60,7 +60,7 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
 Element.prototype.scrollIntoView = vi.fn();
 
 // Mock goals
-const mockGoals: Goal[] = [
+const mockGoals: HierarchicalGoal[] = [
   {
     id: 'goal-1',
     district_id: 'district-1',
@@ -74,6 +74,7 @@ const mockGoals: Goal[] = [
     order_position: 0,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
   {
     id: 'goal-2',
@@ -88,6 +89,7 @@ const mockGoals: Goal[] = [
     order_position: 1,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
   {
     id: 'goal-3',
@@ -102,6 +104,7 @@ const mockGoals: Goal[] = [
     order_position: 2,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
+    children: [],
   },
 ];
 

--- a/src/pages/client/admin/ObjectiveDetail.tsx
+++ b/src/pages/client/admin/ObjectiveDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useSubdomain } from '../../../contexts/SubdomainContext';
 import { useDistrict } from '../../../hooks/useDistricts';
-import { useGoal, useChildGoals, useUpdateGoal } from '../../../hooks/useGoals';
+import { useGoal, useGoals, useUpdateGoal } from '../../../hooks/useGoals';
 import { useMetricsByDistrict, useUpdateMetric } from '../../../hooks/useMetrics';
 import { HeaderSection } from '../../../components/admin/HeaderSection';
 import { GoalCardEditable } from '../../../components/admin/GoalCardEditable';
@@ -12,7 +12,7 @@ import {
   Loader2,
   FolderOpen,
 } from 'lucide-react';
-import type { Goal, Metric } from '../../../lib/types';
+import type { Goal, Metric, HierarchicalGoal } from '../../../lib/types';
 import { toast } from '../../../components/Toast';
 
 /**
@@ -22,13 +22,16 @@ import { toast } from '../../../components/Toast';
 export function ObjectiveDetail() {
   const { objectiveId } = useParams<{ objectiveId: string }>();
   const { slug } = useSubdomain();
-  const { data: district } = useDistrict(slug || '');
+  const { data: district, isLoading: districtLoading } = useDistrict(slug || '');
   const { data: objective, isLoading: objectiveLoading, error: objectiveError } = useGoal(objectiveId || '');
-  const { data: childGoals, isLoading: childrenLoading } = useChildGoals(objectiveId || '');
+  const { data: allGoals, isLoading: goalsLoading } = useGoals(district?.id || '');
   const { data: allMetrics } = useMetricsByDistrict(district?.id || '');
 
-  // Filter Level 1 goals
-  const level1Goals = (childGoals?.filter(g => g.level === 1) || []).sort((a, b) => {
+  // Find the objective in hierarchical data to get nested children
+  const objectiveWithChildren = allGoals?.find(g => g.id === objectiveId) as HierarchicalGoal | undefined;
+
+  // Extract level 1 goals with their level 2 children nested
+  const level1Goals = (objectiveWithChildren?.children || []).sort((a, b) => {
     const aNum = parseFloat(a.goal_number?.replace(/[^\d.]/g, '') || '0');
     const bNum = parseFloat(b.goal_number?.replace(/[^\d.]/g, '') || '0');
     return aNum - bNum;
@@ -44,12 +47,20 @@ export function ObjectiveDetail() {
   const updateGoalMutation = useUpdateGoal();
   const updateMetricMutation = useUpdateMetric();
 
-  const isLoading = objectiveLoading || childrenLoading;
+  // Only show loading if district is loading, or if we have a district and goals are loading
+  const isLoading = objectiveLoading || districtLoading || (!!district?.id && goalsLoading);
 
-  // Auto-expand all goals when they load
+  // Auto-expand all goals when they load (include level 2 goals)
   useEffect(() => {
     if (level1Goals.length > 0) {
-      setExpandedGoalIds(new Set(level1Goals.map(g => g.id)));
+      const allIds: string[] = [];
+      level1Goals.forEach(g => {
+        allIds.push(g.id);
+        // Also include level 2 goal IDs
+        const children = (g as HierarchicalGoal).children || [];
+        children.forEach(child => allIds.push(child.id));
+      });
+      setExpandedGoalIds(new Set(allIds));
     }
   }, [level1Goals]);
 
@@ -226,7 +237,7 @@ export function ObjectiveDetail() {
             Goals
           </h2>
 
-          {(!childGoals || childGoals.length === 0) ? (
+          {level1Goals.length === 0 ? (
             // Empty State
             <div className="bg-white border border-[#e8e6e1] rounded-xl p-8 text-center">
               <div className="w-12 h-12 bg-[#f5f3ef] rounded-full flex items-center justify-center mx-auto mb-4">
@@ -246,31 +257,64 @@ export function ObjectiveDetail() {
               </Link>
             </div>
           ) : (
-            // Goal Cards with Inline Editing - Grid Layout
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            // Goal Cards with Inline Editing - Flex Layout for nested sub-goals
+            <div className="flex flex-col gap-4">
               {level1Goals.map((goal) => {
                 // Get metrics for this goal
                 const goalMetrics = allMetrics?.filter(m => m.goal_id === goal.id) || [];
                 const isExpanded = expandedGoalIds.has(goal.id);
                 const isEditing = editingGoalId === goal.id;
+                // Get level 2 sub-goals (nested in hierarchical data)
+                const level2Goals = (goal as HierarchicalGoal).children || [];
 
                 return (
-                  <GoalCardEditable
-                    key={goal.id}
-                    goal={goal}
-                    metrics={goalMetrics}
-                    isExpanded={isExpanded}
-                    isEditing={isEditing}
-                    isDimmed={isDimmed(goal.id)}
-                    onToggleExpand={() => toggleGoalExpanded(goal.id)}
-                    onEdit={() => handleEditGoal(goal.id)}
-                    onSave={(updates) => handleSaveGoal(goal.id, updates)}
-                    onCancel={() => setEditingGoalId(null)}
-                    editingMetricId={editingMetricId}
-                    onEditMetric={handleEditMetric}
-                    onSaveMetric={handleSaveMetric}
-                    onCancelEditMetric={handleCancelEditMetric}
-                  />
+                  <div key={goal.id}>
+                    <GoalCardEditable
+                      goal={goal}
+                      metrics={goalMetrics}
+                      isExpanded={isExpanded}
+                      isEditing={isEditing}
+                      isDimmed={isDimmed(goal.id)}
+                      onToggleExpand={() => toggleGoalExpanded(goal.id)}
+                      onEdit={() => handleEditGoal(goal.id)}
+                      onSave={(updates) => handleSaveGoal(goal.id, updates)}
+                      onCancel={() => setEditingGoalId(null)}
+                      editingMetricId={editingMetricId}
+                      onEditMetric={handleEditMetric}
+                      onSaveMetric={handleSaveMetric}
+                      onCancelEditMetric={handleCancelEditMetric}
+                    />
+
+                    {/* Level 2 Sub-goals (nested below level 1 when expanded) */}
+                    {isExpanded && level2Goals.length > 0 && (
+                      <div className="ml-6 mt-2 space-y-2">
+                        {level2Goals.map((subGoal) => {
+                          const subGoalMetrics = allMetrics?.filter(m => m.goal_id === subGoal.id) || [];
+                          const isSubGoalExpanded = expandedGoalIds.has(subGoal.id);
+                          const isSubGoalEditing = editingGoalId === subGoal.id;
+
+                          return (
+                            <GoalCardEditable
+                              key={subGoal.id}
+                              goal={subGoal}
+                              metrics={subGoalMetrics}
+                              isExpanded={isSubGoalExpanded}
+                              isEditing={isSubGoalEditing}
+                              isDimmed={isDimmed(subGoal.id)}
+                              onToggleExpand={() => toggleGoalExpanded(subGoal.id)}
+                              onEdit={() => handleEditGoal(subGoal.id)}
+                              onSave={(updates) => handleSaveGoal(subGoal.id, updates)}
+                              onCancel={() => setEditingGoalId(null)}
+                              editingMetricId={editingMetricId}
+                              onEditMetric={handleEditMetric}
+                              onSaveMetric={handleSaveMetric}
+                              onCancelEditMetric={handleCancelEditMetric}
+                            />
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
                 );
               })}
             </div>
@@ -280,7 +324,19 @@ export function ObjectiveDetail() {
 
       {/* Metrics Management Modal */}
       {metricsModalGoalId && (() => {
-        const modalGoal = level1Goals.find(g => g.id === metricsModalGoalId);
+        // Search for goal in level 1 or level 2
+        let modalGoal = level1Goals.find(g => g.id === metricsModalGoalId);
+        if (!modalGoal) {
+          // Search in level 2 goals
+          for (const level1Goal of level1Goals) {
+            const level2Goals = (level1Goal as HierarchicalGoal).children || [];
+            const found = level2Goals.find(g => g.id === metricsModalGoalId);
+            if (found) {
+              modalGoal = found;
+              break;
+            }
+          }
+        }
         const modalMetrics = allMetrics?.filter(m => m.goal_id === metricsModalGoalId) || [];
 
         if (!modalGoal) return null;

--- a/src/pages/client/public/ObjectiveDetail.tsx
+++ b/src/pages/client/public/ObjectiveDetail.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useParams, useOutletContext, Link, useLocation } from 'react-router-dom';
-import { useGoal, useChildGoals } from '../../../hooks/useGoals';
+import { useGoal, useGoals } from '../../../hooks/useGoals';
 import { useMetricsByDistrict } from '../../../hooks/useMetrics';
 import { StatusBadge, MobileGoalBottomSheet, GoalsOverviewGrid } from '../../../components/public';
 import type { StatusType } from '../../../components/public/StatusBadge';
 import { FolderOpen } from 'lucide-react';
-import type { District, Goal, Metric } from '../../../lib/types';
+import type { District, Goal, Metric, HierarchicalGoal } from '../../../lib/types';
 
 interface ObjectiveDetailContext {
   district: District;
@@ -55,10 +55,12 @@ export function ObjectiveDetail() {
   const location = useLocation();
 
   const { data: objective, isLoading: objectiveLoading } = useGoal(goalId!);
-  const { data: childGoals, isLoading: childrenLoading } = useChildGoals(goalId!);
+  const { data: allGoals, isLoading: goalsLoading } = useGoals(context?.district?.id || '');
   const { data: allMetrics, isLoading: metricsLoading } = useMetricsByDistrict(context?.district?.id || '');
 
-  const isLoading = objectiveLoading || childrenLoading || metricsLoading;
+  // Only show loading when we have a district and data is being fetched
+  // If context?.district is missing, let it fall through to "not found" state
+  const isLoading = objectiveLoading || (!!context?.district?.id && (goalsLoading || metricsLoading));
 
   // Mobile carousel state
   const [focusedGoalId, setFocusedGoalId] = useState<string | null>(null);
@@ -168,8 +170,11 @@ export function ObjectiveDetail() {
   const color = getColor(objective, objectiveIndex);
   const colors = colorConfig[color];
 
-  // Get child goals (Level 1) and sort by goal_number
-  const level1Goals = (childGoals?.filter(g => g.level === 1) || []).sort((a, b) => {
+  // Find objective in hierarchical data to get nested children
+  const objectiveWithChildren = allGoals?.find(g => g.id === goalId) as HierarchicalGoal | undefined;
+
+  // Get child goals (Level 1) with their level 2 children nested
+  const level1Goals = (objectiveWithChildren?.children || []).sort((a, b) => {
     const aNum = parseFloat(a.goal_number?.replace(/[^\d.]/g, '') || '0');
     const bNum = parseFloat(b.goal_number?.replace(/[^\d.]/g, '') || '0');
     return aNum - bNum;


### PR DESCRIPTION
## Summary

- Add sub-goals section to `ExpandedGoalPanel` showing nested level 2 goals when a level 1 goal is expanded
- Update `GoalsOverviewGrid` to pass hierarchical children to expanded panel
- Switch from `useChildGoals` to `useGoals` for hierarchical data fetching on both public and admin pages
- Display sub-goals with number badge, title, description, and status indicator
- Update admin `ObjectiveDetail` to show nested sub-goals under level 1 goals with full editing support

## Additional Fixes

- Add critical warning to `CLAUDE.md` about not piping test commands through `head`/`tail` to prevent orphaned vitest processes
- Fix `ContactModal` timer cleanup to prevent test environment errors after unmount

## Test plan

- [ ] Navigate to public district page (e.g., `/westside/objective/{id}`)
- [ ] Click on a Level 1 goal card to expand it
- [ ] Verify sub-goals (1.1.1, 1.1.2, etc.) appear in a "Sub-Goals" section below metrics
- [ ] Verify sub-goal status badges display correctly
- [ ] Navigate to admin objective detail page
- [ ] Verify level 2 sub-goals appear nested under expanded level 1 goals
- [ ] Verify editing works for both level 1 and level 2 goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View and manage nested sub-goals: expanded goals now include a Sub-Goals section showing titles, descriptions, counts, and status badges across public and admin views.

* **Bug Fixes**
  * Cleared form reset timeouts on unmount to prevent stray timers.

* **Tests**
  * Added integration and unit tests covering the Sub-Goals UI and related behaviors.

* **Documentation**
  * Added a critical note warning against piping test output to truncating commands to avoid orphaned workers and system resource exhaustion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->