### PR TITLE
fix: enable API routes in local dev with vercel dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,15 @@ strategic-plan-app/
 ### Essential commands
 
 ```bash
-npm run dev              # Start dev server (http://localhost:5174)
+npm run dev              # Frontend only (Vite on port 5174) — no API routes
+npm run dev:api          # Full-stack: frontend + API routes (vercel dev on port 5174)
 npm test                 # Run tests in watch mode
 npm run test:run         # Run tests once
 npm run build            # Production build
 npm run preview          # Preview production build
 ```
+
+> **`dev` vs `dev:api`:** Use `npm run dev` for frontend-only work (faster startup). Use `npm run dev:api` when you need login/auth or any API route — it runs `vercel dev` which serves both the Vite frontend and the `api/` serverless functions. Requires the Vercel CLI (`npm i -g vercel`).
 
 > **Note for AI agents:** Use `npm run test:run` (single run) instead of `npm test` (watch mode) to avoid spawning multiple background processes.
 >

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:api": "NODE_OPTIONS='--import tsx' vercel dev --listen 5174",
     "build": "vite build",
     "build:staging": "vite build --mode staging",
     "build:check": "tsc -b && vite build",

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,15 @@
 {
   "rewrites": [
     {
+      "source": "/api/auth/(.*)",
+      "destination": "/api/auth/[...all]"
+    },
+    {
       "source": "/api/:path*",
       "destination": "/api/:path*"
     },
     {
-      "source": "/((?!api/).*)",
+      "source": "/((?!api/|@|src/|node_modules/|__vite)[^.]*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## Summary

- Add `npm run dev:api` script that runs `vercel dev` for full-stack local development (frontend + API routes)
- Add `/api/auth/(.*)` rewrite in `vercel.json` so deep Better Auth paths (e.g., `/api/auth/sign-in/email`) reach the `[...all]` catch-all handler
- Fix SPA catch-all rewrite regex to exclude Vite dev paths (`@vite`, `src/`, `node_modules/`, etc.) so `vercel dev` serves both the frontend and API correctly
- Document `dev` vs `dev:api` usage in CLAUDE.md

## Context

After migrating from client-side Supabase to server-side Better Auth (PR #119), `npm run dev` (Vite-only) no longer serves API routes, causing all login/auth calls to 404. `vercel dev` serves both frontend and API but needed two fixes:
1. **Extensionless imports** — `NODE_OPTIONS='--import tsx'` so `vercel dev` resolves `.ts` imports
2. **SPA rewrite conflict** — the catch-all rewrite was rewriting Vite dev module requests (`/@vite/client`, `/app.css`) to `index.html`, breaking the frontend

## Test plan

- [x] `npm run dev:api` starts on port 5174 without errors
- [x] `curl /api/health` returns 200 with DB connected
- [x] `curl /api/auth/ok` returns `{"ok":true}`
- [x] Browser login with sysadmin credentials succeeds and redirects to dashboard
- [x] Build passes
- [x] All 666 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development documentation with clarity on frontend-only versus full-stack development modes
  * Added guidance for developing with API routes support
  * Improved test execution recommendations

* **Chores**
  * Added new development configuration for full-stack API development support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->