### PR TITLE
fix: resolve production API crashes with ESM import extensions

### DIFF
--- a/api/admin/districts.ts
+++ b/api/admin/districts.ts
@@ -1,14 +1,14 @@
 import { eq, sql } from "drizzle-orm";
-import { db } from "../lib/db";
+import { db } from "../lib/db.js";
 import {
   organizations,
   plans,
   goals,
   metrics,
   organizationMembers,
-} from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/admin/districts

--- a/api/admin/members.ts
+++ b/api/admin/members.ts
@@ -1,11 +1,11 @@
 import { eq, desc } from "drizzle-orm";
-import { db } from "../lib/db";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
-} from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/admin/members

--- a/api/admin/recent-users.ts
+++ b/api/admin/recent-users.ts
@@ -1,8 +1,8 @@
 import { desc } from "drizzle-orm";
-import { db } from "../lib/db";
-import { user } from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { user } from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/admin/recent-users

--- a/api/admin/stats.ts
+++ b/api/admin/stats.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { db } from "../lib/db";
+import { db } from "../lib/db.js";
 import {
   organizations,
   plans,
@@ -7,9 +7,9 @@ import {
   metrics,
   schools,
   user,
-} from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/admin/stats

--- a/api/auth/[...all].ts
+++ b/api/auth/[...all].ts
@@ -1,4 +1,4 @@
-import { auth } from "../lib/auth";
+import { auth } from "../lib/auth.js";
 
 export async function GET(request: Request) {
   return auth.handler(request);

--- a/api/contact/[id].ts
+++ b/api/contact/[id].ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../lib/db";
-import { contactSubmissions } from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { contactSubmissions } from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /** Map a Drizzle contact submission row to snake_case for the frontend */
 function contactToSnake(c: typeof contactSubmissions.$inferSelect) {

--- a/api/contact/index.ts
+++ b/api/contact/index.ts
@@ -1,8 +1,8 @@
 import { desc } from "drizzle-orm";
-import { db } from "../lib/db";
-import { contactSubmissions } from "../lib/schema/index";
-import { requireSystemAdmin } from "../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../lib/response";
+import { db } from "../lib/db.js";
+import { contactSubmissions } from "../lib/schema/index.js";
+import { requireSystemAdmin } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../lib/response.js";
 
 /** Map a Drizzle contact submission row to snake_case for the frontend */
 function contactToSnake(c: typeof contactSubmissions.$inferSelect) {

--- a/api/goals/[id]/children.ts
+++ b/api/goals/[id]/children.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { goals, metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { goals, metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/api/goals/[id]/index.ts
+++ b/api/goals/[id]/index.ts
@@ -1,15 +1,15 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../../lib/db";
+import { db } from "../../lib/db.js";
 import {
   goals,
   metrics,
   plans,
   organizations,
   organizationMembers,
-} from "../../lib/schema/index";
-import { requireAuth, hasMinimumRole } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/schema/index.js";
+import { requireAuth, hasMinimumRole } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/api/goals/[id]/metrics.ts
+++ b/api/goals/[id]/metrics.ts
@@ -1,15 +1,15 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../../lib/db";
+import { db } from "../../lib/db.js";
 import {
   goals,
   metrics,
   plans,
   organizations,
   organizationMembers,
-} from "../../lib/schema/index";
-import { requireAuth, hasMinimumRole } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/schema/index.js";
+import { requireAuth, hasMinimumRole } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/api/goals/renumber.ts
+++ b/api/goals/renumber.ts
@@ -1,9 +1,9 @@
 import { eq, and, isNull, asc } from "drizzle-orm";
-import { db } from "../lib/db";
-import { goals } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { getOrgSlugForPlan } from "../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { goals } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { getOrgSlugForPlan } from "../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 // ---------------------------------------------------------------------------
 // PUT /api/goals/renumber — Renumber goals sequentially

--- a/api/goals/reorder.ts
+++ b/api/goals/reorder.ts
@@ -1,9 +1,9 @@
 import { eq, inArray } from "drizzle-orm";
-import { db } from "../lib/db";
-import { goals, plans } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { getOrgSlugForGoal } from "../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { goals, plans } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { getOrgSlugForGoal } from "../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 // ---------------------------------------------------------------------------
 // PUT /api/goals/reorder — Reorder goals by updating order_position

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,5 +1,5 @@
-import { db } from "./lib/db";
-import { organizations } from "./lib/schema/index";
+import { db } from "./lib/db.js";
+import { organizations } from "./lib/schema/index.js";
 
 export async function GET() {
   try {

--- a/api/imports/autofix/apply.ts
+++ b/api/imports/autofix/apply.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { importSessions, organizations, stagedGoals } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { importSessions, organizations, stagedGoals } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function stagedGoalToSnake(sg: typeof stagedGoals.$inferSelect) {
   return {

--- a/api/imports/autofix/bulk.ts
+++ b/api/imports/autofix/bulk.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { importSessions, organizations, stagedGoals } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { importSessions, organizations, stagedGoals } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function stagedGoalToSnake(sg: typeof stagedGoals.$inferSelect) {
   return {

--- a/api/imports/sessions/[id]/execute.ts
+++ b/api/imports/sessions/[id]/execute.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from "drizzle-orm";
-import { db } from "../../../lib/db";
+import { db } from "../../../lib/db.js";
 import {
   importSessions,
   stagedGoals,
@@ -8,9 +8,9 @@ import {
   metrics,
   plans,
   organizations,
-} from "../../../lib/schema/index";
-import { requireOrgMember } from "../../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../../lib/response";
+} from "../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
 
 function extractSessionId(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");

--- a/api/imports/sessions/[id]/index.ts
+++ b/api/imports/sessions/[id]/index.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../../lib/db";
-import { importSessions, organizations } from "../../../lib/schema/index";
-import { requireOrgMember } from "../../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../../lib/response";
+import { db } from "../../../lib/db.js";
+import { importSessions, organizations } from "../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
 
 function sessionToSnake(s: typeof importSessions.$inferSelect) {
   return {

--- a/api/imports/sessions/[id]/stage.ts
+++ b/api/imports/sessions/[id]/stage.ts
@@ -1,13 +1,13 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../../../lib/db";
+import { db } from "../../../lib/db.js";
 import {
   importSessions,
   organizations,
   stagedGoals,
   stagedMetrics,
-} from "../../../lib/schema/index";
-import { requireOrgMember } from "../../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../../lib/response";
+} from "../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
 
 function extractSessionId(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");

--- a/api/imports/sessions/[id]/staged-goals/[goalId].ts
+++ b/api/imports/sessions/[id]/staged-goals/[goalId].ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../../../lib/db";
-import { importSessions, organizations, stagedGoals } from "../../../../lib/schema/index";
-import { requireOrgMember } from "../../../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../../../lib/response";
+import { db } from "../../../../lib/db.js";
+import { importSessions, organizations, stagedGoals } from "../../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../../../lib/response.js";
 
 function stagedGoalToSnake(sg: typeof stagedGoals.$inferSelect) {
   return {

--- a/api/imports/sessions/[id]/staged.ts
+++ b/api/imports/sessions/[id]/staged.ts
@@ -1,13 +1,13 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../../lib/db";
+import { db } from "../../../lib/db.js";
 import {
   importSessions,
   organizations,
   stagedGoals,
   stagedMetrics,
-} from "../../../lib/schema/index";
-import { requireOrgMember } from "../../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../../lib/response";
+} from "../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
 
 function stagedGoalToSnake(sg: typeof stagedGoals.$inferSelect) {
   return {

--- a/api/imports/sessions/index.ts
+++ b/api/imports/sessions/index.ts
@@ -1,8 +1,8 @@
 import { eq, desc } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { importSessions, organizations } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { importSessions, organizations } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function sessionToSnake(s: typeof importSessions.$inferSelect) {
   return {

--- a/api/lib/auth.ts
+++ b/api/lib/auth.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { db } from "./db";
-import * as schema from "./schema/index";
+import { db } from "./db.js";
+import * as schema from "./schema/index.js";
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined),
@@ -36,6 +36,8 @@ export const auth = betterAuth({
       "http://localhost:5173",
       "http://localhost:5174",
       "http://lvh.me:5174",
+      "https://stratadash.org",
+      "https://www.stratadash.org",
     ];
     if (process.env.VITE_APP_URL) {
       origins.push(process.env.VITE_APP_URL);
@@ -43,6 +45,10 @@ export const auth = betterAuth({
     // Allow any subdomain of lvh.me for local dev
     const origin = request?.headers.get("origin");
     if (origin && /^https?:\/\/.*\.lvh\.me:5174$/.test(origin)) {
+      origins.push(origin);
+    }
+    // Allow any subdomain of stratadash.org for production
+    if (origin && /^https:\/\/.*\.stratadash\.org$/.test(origin)) {
       origins.push(origin);
     }
     // Allow this project's Vercel preview deployment URLs

--- a/api/lib/db.ts
+++ b/api/lib/db.ts
@@ -1,6 +1,6 @@
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
-import * as schema from "./schema/index";
+import * as schema from "./schema/index.js";
 
 const sql = neon(process.env.DATABASE_URL!);
 export const db = drizzle(sql, { schema });

--- a/api/lib/helpers/org-lookup.ts
+++ b/api/lib/helpers/org-lookup.ts
@@ -1,12 +1,12 @@
 import { eq } from "drizzle-orm";
-import { db } from "../db";
+import { db } from "../db.js";
 import {
   goals,
   importSessions,
   metrics,
   plans,
   organizations,
-} from "../schema/index";
+} from "../schema/index.js";
 
 /**
  * Look up the organization for a goal via goal → plan → organization.

--- a/api/lib/middleware/auth.ts
+++ b/api/lib/middleware/auth.ts
@@ -1,12 +1,12 @@
 import { eq, and } from "drizzle-orm";
-import { auth } from "../auth";
-import { db } from "../db";
-import { organizations, organizationMembers } from "../schema/index";
-import { hasMinimumRole } from "./roles";
-import type { OrgRole } from "./roles";
+import { auth } from "../auth.js";
+import { db } from "../db.js";
+import { organizations, organizationMembers } from "../schema/index.js";
+import { hasMinimumRole } from "./roles.js";
+import type { OrgRole } from "./roles.js";
 
-export { hasMinimumRole } from "./roles";
-export type { OrgRole } from "./roles";
+export { hasMinimumRole } from "./roles.js";
+export type { OrgRole } from "./roles.js";
 
 /** User type with additionalFields from Better Auth config */
 export interface SessionUser {

--- a/api/lib/middleware/index.ts
+++ b/api/lib/middleware/index.ts
@@ -3,4 +3,4 @@ export {
   requireOrgMember,
   requireSystemAdmin,
   hasMinimumRole,
-} from "./auth";
+} from "./auth.js";

--- a/api/lib/schema/goals.ts
+++ b/api/lib/schema/goals.ts
@@ -12,9 +12,9 @@ import {
   jsonb,
   foreignKey,
 } from "drizzle-orm/pg-core";
-import { plans } from "./plans";
-import { organizations } from "./organizations";
-import { schools } from "./schools";
+import { plans } from "./plans.js";
+import { organizations } from "./organizations.js";
+import { schools } from "./schools.js";
 
 export const goals = pgTable(
   "goals",

--- a/api/lib/schema/imports.ts
+++ b/api/lib/schema/imports.ts
@@ -11,8 +11,8 @@ import {
   index,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
-import { organizations } from "./organizations";
-import { goals, metrics } from "./goals";
+import { organizations } from "./organizations.js";
+import { goals, metrics } from "./goals.js";
 
 export const importSessions = pgTable(
   "import_sessions",

--- a/api/lib/schema/index.ts
+++ b/api/lib/schema/index.ts
@@ -1,19 +1,19 @@
-export { user, session, account, verification } from "./auth";
+export { user, session, account, verification } from "./auth.js";
 export {
   organizations,
   organizationMembers,
   organizationInvitations,
-} from "./organizations";
-export { plans } from "./plans";
-export { goals, metrics } from "./goals";
-export { schools } from "./schools";
-export { contactSubmissions } from "./contact";
-export { metricTimeSeries } from "./metricTimeSeries";
-export { schoolAdmins } from "./schoolAdmins";
+} from "./organizations.js";
+export { plans } from "./plans.js";
+export { goals, metrics } from "./goals.js";
+export { schools } from "./schools.js";
+export { contactSubmissions } from "./contact.js";
+export { metricTimeSeries } from "./metricTimeSeries.js";
+export { schoolAdmins } from "./schoolAdmins.js";
 export {
   importSessions,
   stagedGoals,
   stagedMetrics,
-} from "./imports";
-export { statusOverrides } from "./progress";
-export { stockPhotos } from "./stockPhotos";
+} from "./imports.js";
+export { statusOverrides } from "./progress.js";
+export { stockPhotos } from "./stockPhotos.js";

--- a/api/lib/schema/metricTimeSeries.ts
+++ b/api/lib/schema/metricTimeSeries.ts
@@ -8,8 +8,8 @@ import {
   index,
   unique,
 } from "drizzle-orm/pg-core";
-import { metrics } from "./goals";
-import { organizations } from "./organizations";
+import { metrics } from "./goals.js";
+import { organizations } from "./organizations.js";
 
 export const metricTimeSeries = pgTable(
   "metric_time_series",

--- a/api/lib/schema/organizations.ts
+++ b/api/lib/schema/organizations.ts
@@ -9,7 +9,7 @@ import {
   index,
   unique,
 } from "drizzle-orm/pg-core";
-import { user } from "./auth";
+import { user } from "./auth.js";
 
 export const organizations = pgTable(
   "organizations",

--- a/api/lib/schema/plans.ts
+++ b/api/lib/schema/plans.ts
@@ -11,8 +11,8 @@ import {
   uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { isNull, isNotNull } from "drizzle-orm";
-import { organizations } from "./organizations";
-import { schools } from "./schools";
+import { organizations } from "./organizations.js";
+import { schools } from "./schools.js";
 
 export const plans = pgTable(
   "plans",

--- a/api/lib/schema/progress.ts
+++ b/api/lib/schema/progress.ts
@@ -7,7 +7,7 @@ import {
   index,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
-import { goals } from "./goals";
+import { goals } from "./goals.js";
 
 export const statusOverrides = pgTable(
   "status_overrides",

--- a/api/lib/schema/schoolAdmins.ts
+++ b/api/lib/schema/schoolAdmins.ts
@@ -6,8 +6,8 @@ import {
   unique,
   index,
 } from "drizzle-orm/pg-core";
-import { user } from "./auth";
-import { schools } from "./schools";
+import { user } from "./auth.js";
+import { schools } from "./schools.js";
 
 export const schoolAdmins = pgTable(
   "school_admins",

--- a/api/lib/schema/schools.ts
+++ b/api/lib/schema/schools.ts
@@ -8,7 +8,7 @@ import {
   index,
   unique,
 } from "drizzle-orm/pg-core";
-import { organizations } from "./organizations";
+import { organizations } from "./organizations.js";
 
 export const schools = pgTable(
   "schools",

--- a/api/metrics/[id]/index.ts
+++ b/api/metrics/[id]/index.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForMetric, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForMetric, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle metrics row to snake_case for the frontend */
 function metricToSnake(m: typeof metrics.$inferSelect) {

--- a/api/metrics/[id]/time-series.ts
+++ b/api/metrics/[id]/time-series.ts
@@ -1,12 +1,12 @@
 import { eq, and, asc } from "drizzle-orm";
-import { db } from "../../lib/db";
+import { db } from "../../lib/db.js";
 import {
   metrics,
   metricTimeSeries,
-} from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForMetric, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForMetric, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle metricTimeSeries row to snake_case for the frontend */
 function timeSeriesEntryToSnake(e: typeof metricTimeSeries.$inferSelect) {

--- a/api/metrics/[id]/value.ts
+++ b/api/metrics/[id]/value.ts
@@ -1,13 +1,13 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
+import { db } from "../../lib/db.js";
 import {
   metrics,
   goals,
   plans,
   organizations,
-} from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle metrics row to snake_case for the frontend */
 function metricToSnake(m: typeof metrics.$inferSelect) {

--- a/api/metrics/bulk.ts
+++ b/api/metrics/bulk.ts
@@ -1,9 +1,9 @@
 import { eq, inArray } from "drizzle-orm";
-import { db } from "../lib/db";
-import { metrics, goals, plans } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { getOrgSlugForMetric } from "../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { metrics, goals, plans } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { getOrgSlugForMetric } from "../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /** Map a Drizzle metrics row to snake_case for the frontend */
 function metricToSnake(m: typeof metrics.$inferSelect) {

--- a/api/metrics/reorder.ts
+++ b/api/metrics/reorder.ts
@@ -1,9 +1,9 @@
 import { eq, inArray } from "drizzle-orm";
-import { db } from "../lib/db";
-import { metrics, goals, plans } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { getOrgSlugForMetric } from "../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { metrics, goals, plans } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { getOrgSlugForMetric } from "../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * PUT /api/metrics/reorder - Reorder metrics

--- a/api/organizations/[slug]/goals.ts
+++ b/api/organizations/[slug]/goals.ts
@@ -1,8 +1,8 @@
 import { eq, and, sql, asc } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { organizations, plans, goals, metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { organizations, plans, goals, metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../../lib/response.js";
 
 /** Map a Drizzle goal row to snake_case for the frontend */
 function goalToSnakeCase(

--- a/api/organizations/[slug]/index.ts
+++ b/api/organizations/[slug]/index.ts
@@ -1,12 +1,12 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { organizations } from "../../lib/schema/index";
+import { db } from "../../lib/db.js";
+import { organizations } from "../../lib/schema/index.js";
 import {
   requireAuth,
   requireOrgMember,
   requireSystemAdmin,
-} from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle organization row to snake_case for the frontend */
 function toSnakeCase(org: typeof organizations.$inferSelect) {

--- a/api/organizations/[slug]/metrics.ts
+++ b/api/organizations/[slug]/metrics.ts
@@ -1,8 +1,8 @@
 import { eq, and, asc } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { organizations, plans, goals, metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { organizations, plans, goals, metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../../lib/response.js";
 
 /** Map a Drizzle metric row to snake_case for the frontend */
 function metricToSnakeCase(metric: typeof metrics.$inferSelect) {

--- a/api/organizations/[slug]/plans.ts
+++ b/api/organizations/[slug]/plans.ts
@@ -1,8 +1,8 @@
 import { eq, and, asc } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { organizations, plans } from "../../lib/schema/index";
-import { requireAuth, requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { organizations, plans } from "../../lib/schema/index.js";
+import { requireAuth, requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../../lib/response.js";
 
 /** Map a Drizzle plan row to snake_case for the frontend */
 function planToSnakeCase(plan: typeof plans.$inferSelect) {

--- a/api/organizations/[slug]/schools/index.ts
+++ b/api/organizations/[slug]/schools/index.ts
@@ -1,8 +1,8 @@
 import { eq, and, asc } from "drizzle-orm";
-import { db } from "../../../lib/db";
-import { organizations, schools } from "../../../lib/schema/index";
-import { requireOrgMember } from "../../../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../../../lib/response";
+import { db } from "../../../lib/db.js";
+import { organizations, schools } from "../../../lib/schema/index.js";
+import { requireOrgMember } from "../../../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../../../lib/response.js";
 
 /** Map a Drizzle school row to snake_case for the frontend */
 function schoolToSnakeCase(school: typeof schools.$inferSelect) {

--- a/api/organizations/index.ts
+++ b/api/organizations/index.ts
@@ -1,14 +1,14 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../lib/db";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
-} from "../lib/schema/index";
+} from "../lib/schema/index.js";
 import {
   requireAuth,
   requireSystemAdmin,
-} from "../lib/middleware/auth";
-import { jsonOk, jsonError, parsePagination } from "../lib/response";
+} from "../lib/middleware/auth.js";
+import { jsonOk, jsonError, parsePagination } from "../lib/response.js";
 
 /** Map a Drizzle organization row to snake_case for the frontend */
 function toSnakeCase(org: typeof organizations.$inferSelect) {

--- a/api/plans/[id]/goals.ts
+++ b/api/plans/[id]/goals.ts
@@ -1,9 +1,9 @@
 import { eq, asc } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { plans, goals, metrics, organizations } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { plans, goals, metrics, organizations } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function goalToSnake(row: any) {

--- a/api/plans/[id]/index.ts
+++ b/api/plans/[id]/index.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { plans, organizations } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { plans, organizations } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function toSnake(row: typeof plans.$inferSelect) {
   return {

--- a/api/plans/[id]/summary.ts
+++ b/api/plans/[id]/summary.ts
@@ -1,9 +1,9 @@
 import { eq, and, count } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { plans, goals, metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { plans, goals, metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForPlan, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function toSnake(row: typeof plans.$inferSelect) {
   return {

--- a/api/plans/active/[slug]/index.ts
+++ b/api/plans/active/[slug]/index.ts
@@ -1,13 +1,13 @@
 import { eq, and, count, inArray } from "drizzle-orm";
-import { db } from "../../../lib/db";
+import { db } from "../../../lib/db.js";
 import {
   plans,
   goals,
   organizations,
   organizationMembers,
-} from "../../../lib/schema/index";
-import { jsonOk, jsonError } from "../../../lib/response";
-import { auth } from "../../../lib/auth";
+} from "../../../lib/schema/index.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
+import { auth } from "../../../lib/auth.js";
 
 function toSnake(row: typeof plans.$inferSelect) {
   return {

--- a/api/plans/reorder.ts
+++ b/api/plans/reorder.ts
@@ -1,9 +1,9 @@
 import { eq, inArray } from "drizzle-orm";
-import { db } from "../lib/db";
-import { plans } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { getOrgSlugForPlan } from "../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { plans } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { getOrgSlugForPlan } from "../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * PUT /api/plans/reorder - Reorder plans by updating order_position

--- a/api/progress/[goalId]/breakdown.ts
+++ b/api/progress/[goalId]/breakdown.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { goals, metrics } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { goals, metrics } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal, isPublicOrg } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function goalToSnake(g: Record<string, unknown>) {
   return {

--- a/api/progress/[goalId]/display-mode.ts
+++ b/api/progress/[goalId]/display-mode.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { goals } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { goals } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function extractGoalId(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");

--- a/api/progress/[goalId]/override.ts
+++ b/api/progress/[goalId]/override.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { goals, statusOverrides } from "../../lib/schema/index";
-import { requireAuth, requireOrgMember } from "../../lib/middleware/auth";
-import { getOrgSlugForGoal } from "../../lib/helpers/org-lookup";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { goals, statusOverrides } from "../../lib/schema/index.js";
+import { requireAuth, requireOrgMember } from "../../lib/middleware/auth.js";
+import { getOrgSlugForGoal } from "../../lib/helpers/org-lookup.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function goalToSnake(g: Record<string, unknown>) {
   return {

--- a/api/progress/recalculate/[orgId].ts
+++ b/api/progress/recalculate/[orgId].ts
@@ -1,14 +1,14 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../../lib/db";
+import { db } from "../../lib/db.js";
 import {
   goals,
   metrics,
   plans,
   organizations,
   organizationMembers,
-} from "../../lib/schema/index";
-import { requireAuth } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+} from "../../lib/schema/index.js";
+import { requireAuth } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 function extractOrgId(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");

--- a/api/school-admins/[schoolId].ts
+++ b/api/school-admins/[schoolId].ts
@@ -1,8 +1,8 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../lib/db";
-import { organizations, schoolAdmins, schools, user } from "../lib/schema/index";
-import { requireOrgMember } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+import { db } from "../lib/db.js";
+import { organizations, schoolAdmins, schools, user } from "../lib/schema/index.js";
+import { requireOrgMember } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /** Map a school admin + user join to snake_case for the frontend */
 function adminWithUserToSnake(row: {

--- a/api/school-admins/check.ts
+++ b/api/school-admins/check.ts
@@ -1,13 +1,13 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../lib/db";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
   schoolAdmins,
   schools,
-} from "../lib/schema/index";
-import { requireAuth } from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/school-admins/check?district=slug&school=slug

--- a/api/school-admins/index.ts
+++ b/api/school-admins/index.ts
@@ -1,11 +1,11 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../lib/db";
-import { schoolAdmins, schools, organizations } from "../lib/schema/index";
+import { db } from "../lib/db.js";
+import { schoolAdmins, schools, organizations } from "../lib/schema/index.js";
 import {
   requireAuth,
   requireOrgMember,
-} from "../lib/middleware/auth";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 /** Map a Drizzle school admin row to snake_case for the frontend */
 function schoolAdminToSnake(sa: typeof schoolAdmins.$inferSelect) {

--- a/api/schools/[id]/index.ts
+++ b/api/schools/[id]/index.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { schools, organizations } from "../../lib/schema/index";
-import { requireOrgMember } from "../../lib/middleware/auth";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { schools, organizations } from "../../lib/schema/index.js";
+import { requireOrgMember } from "../../lib/middleware/auth.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle school row to snake_case for the frontend */
 function schoolToSnake(s: typeof schools.$inferSelect) {

--- a/api/schools/[id]/summary.ts
+++ b/api/schools/[id]/summary.ts
@@ -1,7 +1,7 @@
 import { eq, and, count } from "drizzle-orm";
-import { db } from "../../lib/db";
-import { schools, plans, goals, metrics } from "../../lib/schema/index";
-import { jsonOk, jsonError } from "../../lib/response";
+import { db } from "../../lib/db.js";
+import { schools, plans, goals, metrics } from "../../lib/schema/index.js";
+import { jsonOk, jsonError } from "../../lib/response.js";
 
 /** Map a Drizzle school row to snake_case for the frontend */
 function schoolToSnake(s: typeof schools.$inferSelect) {

--- a/api/schools/by-slug/[districtSlug]/[schoolSlug].ts
+++ b/api/schools/by-slug/[districtSlug]/[schoolSlug].ts
@@ -1,7 +1,7 @@
 import { eq, and } from "drizzle-orm";
-import { db } from "../../../lib/db";
-import { schools, organizations } from "../../../lib/schema/index";
-import { jsonOk, jsonError } from "../../../lib/response";
+import { db } from "../../../lib/db.js";
+import { schools, organizations } from "../../../lib/schema/index.js";
+import { jsonOk, jsonError } from "../../../lib/response.js";
 
 /** Map a Drizzle school row to snake_case for the frontend */
 function schoolToSnake(s: typeof schools.$inferSelect) {

--- a/api/stock-photos.ts
+++ b/api/stock-photos.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
-import { db } from "./lib/db";
-import { stockPhotos } from "./lib/schema/index";
-import { jsonOk, jsonError } from "./lib/response";
+import { db } from "./lib/db.js";
+import { stockPhotos } from "./lib/schema/index.js";
+import { jsonOk, jsonError } from "./lib/response.js";
 
 /**
  * GET /api/stock-photos

--- a/api/user/dashboard.ts
+++ b/api/user/dashboard.ts
@@ -1,14 +1,14 @@
 import { eq, and, inArray, count } from "drizzle-orm";
-import { requireAuth } from "../lib/middleware/auth";
-import { db } from "../lib/db";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
   plans,
   goals,
   metrics,
-} from "../lib/schema/index";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 export async function GET(request: Request) {
   try {

--- a/api/user/districts.ts
+++ b/api/user/districts.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
-import { requireAuth } from "../lib/middleware/auth";
-import { db } from "../lib/db";
-import { organizations, organizationMembers } from "../lib/schema/index";
-import { jsonOk, jsonError } from "../lib/response";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { db } from "../lib/db.js";
+import { organizations, organizationMembers } from "../lib/schema/index.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 function orgToSnake(o: typeof organizations.$inferSelect) {
   return {

--- a/api/user/memberships.ts
+++ b/api/user/memberships.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
-import { requireAuth } from "../lib/middleware/auth";
-import { db } from "../lib/db";
-import { organizations, organizationMembers } from "../lib/schema/index";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { db } from "../lib/db.js";
+import { organizations, organizationMembers } from "../lib/schema/index.js";
 
 export async function GET(request: Request) {
   try {

--- a/api/user/plans-with-counts.ts
+++ b/api/user/plans-with-counts.ts
@@ -1,13 +1,13 @@
 import { eq, inArray, desc, and, count, sql } from "drizzle-orm";
-import { requireAuth } from "../lib/middleware/auth";
-import { db } from "../lib/db";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
   plans,
   goals,
-} from "../lib/schema/index";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 function planToSnake(p: typeof plans.$inferSelect) {
   return {

--- a/api/user/plans.ts
+++ b/api/user/plans.ts
@@ -1,12 +1,12 @@
 import { eq, inArray, desc } from "drizzle-orm";
-import { requireAuth } from "../lib/middleware/auth";
-import { db } from "../lib/db";
+import { requireAuth } from "../lib/middleware/auth.js";
+import { db } from "../lib/db.js";
 import {
   organizations,
   organizationMembers,
   plans,
-} from "../lib/schema/index";
-import { jsonOk, jsonError } from "../lib/response";
+} from "../lib/schema/index.js";
+import { jsonOk, jsonError } from "../lib/response.js";
 
 function planToSnake(p: typeof plans.$inferSelect) {
   return {


### PR DESCRIPTION
## Summary
- **Added `.js` extensions** to all 257 relative imports across 53 API files — Vercel's Node.js runtime requires explicit extensions for ESM (`"type": "module"`)
- **Added production domain** (`stratadash.org` + wildcard subdomains) to Better Auth `trustedOrigins`
- **Added missing Vercel env vars** (`BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `BETTER_AUTH_COOKIE_DOMAIN`) for production — done via CLI, not in code

## Root Cause
Vercel's Node.js runtime no longer bundles API functions into single files. With `"type": "module"` in `package.json`, extensionless imports like `from "./lib/db"` fail at runtime with `ERR_MODULE_NOT_FOUND`. All API routes returned `FUNCTION_INVOCATION_FAILED` (500).

## Test plan
- [x] Production deployed and verified via `vercel --prod`
- [x] `GET /api/health` → 200 (DB connected)
- [x] `GET /api/auth/get-session` → 200
- [x] `POST /api/auth/sign-in/email` → 200 (login works)
- [x] All 666 unit tests pass
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module import paths for improved ES module compatibility. No changes to application functionality or user-facing features.
  * Expanded authentication to support the stratadash.org domain and all subdomains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->