### PR TITLE
feat: add cross-district Strategic Plans page to root domain dashboard

### DIFF
--- a/e2e/admin/strategic-plans.spec.ts
+++ b/e2e/admin/strategic-plans.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../helpers/login-page';
+
+/**
+ * Strategic Plans — Root Domain Dashboard Tests
+ *
+ * Verifies that the Strategic Plans page works from the root domain dashboard.
+ * Tests navigation, data display, and plan-organization scoping.
+ *
+ * Run with: npx playwright test e2e/admin/strategic-plans.spec.ts --workers=1
+ */
+
+test.describe('Strategic Plans - Root Domain Dashboard', () => {
+  let loginPage: LoginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await page.context().clearCookies();
+
+    // Login as system admin on root domain (no subdomain param = root)
+    await page.goto('/login');
+    await loginPage.login('sysadmin@stratadash.com', 'Stratadash123!');
+
+    // Wait for redirect to dashboard
+    await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+  });
+
+  test('navigate to Strategic Plans page from sidebar', async ({ page }) => {
+    const sidebar = page.locator('aside').first();
+
+    // Click "Strategic plans" link in sidebar
+    await sidebar.locator('a:has-text("Strategic plans")').click();
+
+    // Verify navigation to plans page
+    await expect(page).toHaveURL(/\/dashboard\/plans/);
+
+    // Verify page title renders
+    await expect(
+      page.locator('h1:has-text("Strategic Plans")')
+    ).toBeVisible();
+  });
+
+  test('plans list shows correct data with district badges', async ({ page }) => {
+    await page.goto('/dashboard/plans');
+
+    // Wait for plans to load (loading skeleton disappears)
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // Verify table headers
+    await expect(page.locator('th:has-text("Plan")')).toBeVisible();
+    await expect(page.locator('th:has-text("District")')).toBeVisible();
+    await expect(page.locator('th:has-text("Type")')).toBeVisible();
+    await expect(page.locator('th:has-text("Objectives")')).toBeVisible();
+    await expect(page.locator('th:has-text("Status")')).toBeVisible();
+
+    // Verify at least one plan row exists (seeded data)
+    const planRows = page.locator('tbody tr');
+    await expect(planRows.first()).toBeVisible();
+  });
+
+  test('click plan navigates to district admin detail', async ({ page }) => {
+    await page.goto('/dashboard/plans');
+
+    // Wait for table to load
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // Click the first plan link
+    const firstPlanLink = page.locator('tbody tr:first-child a').first();
+    const href = await firstPlanLink.getAttribute('href');
+
+    // The link should point to a district admin page
+    expect(href).toContain('/admin/plans/');
+  });
+
+  test('dashboard "View all plans" link navigates to plans list', async ({ page }) => {
+    // Start on dashboard
+    await page.goto('/dashboard');
+
+    // Click "View all plans" link
+    const viewAllLink = page.locator('a:has-text("View all plans")');
+    await expect(viewAllLink).toBeVisible();
+    await viewAllLink.click();
+
+    // Should navigate to plans page
+    await expect(page).toHaveURL(/\/dashboard\/plans/);
+  });
+
+  test('search filter works', async ({ page }) => {
+    await page.goto('/dashboard/plans');
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // Type in search box
+    const searchInput = page.locator('input[placeholder*="Search"]');
+    await searchInput.fill('nonexistent-plan-xyz');
+
+    // Should show "No plans match" message
+    await expect(
+      page.locator('text=No plans match your filters')
+    ).toBeVisible();
+  });
+});
+
+test.describe('Strategic Plans - District Admin', () => {
+  let loginPage: LoginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await page.context().clearCookies();
+
+    // Login as Westside admin
+    await page.goto('/login?subdomain=westside');
+    await loginPage.login('admin@westside66.org', 'Westside123!');
+
+    // Wait for redirect to admin dashboard
+    await page.waitForURL(/\/admin/, { timeout: 15000 });
+  });
+
+  test('plans are scoped to correct organization', async ({ page }) => {
+    const sidebar = page.locator('aside').first();
+
+    // Navigate to Plans
+    await sidebar.locator('a:has-text("Plans"), button:has-text("Plans")').click();
+    await expect(page).toHaveURL(/\/admin\/plans/);
+
+    // Wait for plans list
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // The plans list title should be visible
+    await expect(
+      page.locator('h1:has-text("Strategic Plans")')
+    ).toBeVisible();
+  });
+});

--- a/e2e/admin/strategic-plans.spec.ts
+++ b/e2e/admin/strategic-plans.spec.ts
@@ -64,12 +64,15 @@ test.describe('Strategic Plans - Root Domain Dashboard', () => {
     // Wait for table to load
     await page.waitForSelector('table', { timeout: 10000 });
 
-    // Click the first plan link
+    // Get the first plan link and verify its href
     const firstPlanLink = page.locator('tbody tr:first-child a').first();
     const href = await firstPlanLink.getAttribute('href');
-
-    // The link should point to a district admin page
     expect(href).toContain('/admin/plans/');
+
+    // Click the link and verify navigation to district admin detail page
+    await firstPlanLink.click();
+    await page.waitForURL(/\/admin\/plans\//, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/admin\/plans\//);
   });
 
   test('dashboard "View all plans" link navigates to plans list', async ({ page }) => {

--- a/src/lib/services/__tests__/plans.service.test.ts
+++ b/src/lib/services/__tests__/plans.service.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { PlansService } from '../plans.service';
+
+describe('PlansService', () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('getByDistrictSlug', () => {
+    it('should fetch plans for a district by slug', async () => {
+      const mockPlans = [
+        {
+          id: 'plan-1',
+          district_id: 'district-123',
+          name: 'Strategic Plan 2025',
+          slug: 'strategic-plan-2025',
+          is_public: true,
+          is_active: true,
+          order_position: 0,
+        },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPlans),
+      });
+
+      const result = await PlansService.getByDistrictSlug('westside');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/organizations/westside/plans',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Strategic Plan 2025');
+    });
+
+    it('should return empty array when district has no plans', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      });
+
+      const result = await PlansService.getByDistrictSlug('empty-district');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw error on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ error: 'Database error' }),
+      });
+
+      await expect(PlansService.getByDistrictSlug('westside')).rejects.toThrow();
+    });
+  });
+
+  describe('getByDistrictId', () => {
+    it('should look up district slug then fetch plans', async () => {
+      const mockDistrict = {
+        id: 'district-123',
+        slug: 'westside',
+        name: 'Westside District',
+      };
+      const mockPlans = [
+        {
+          id: 'plan-1',
+          district_id: 'district-123',
+          name: 'Westside Plan',
+          slug: 'westside-plan',
+          is_public: true,
+          is_active: true,
+          order_position: 0,
+        },
+      ];
+
+      // First call: district lookup
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockDistrict),
+      });
+
+      // Second call: plans fetch
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPlans),
+      });
+
+      const result = await PlansService.getByDistrictId('district-123');
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost/api/organizations?id=district-123',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost/api/organizations/westside/plans',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('plan-1');
+    });
+  });
+
+  describe('getById', () => {
+    it('should fetch a single plan by ID', async () => {
+      const mockPlan = {
+        id: 'plan-123',
+        district_id: 'district-123',
+        name: 'Test Plan',
+        slug: 'test-plan',
+        is_public: true,
+        is_active: true,
+        order_position: 0,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPlan),
+      });
+
+      const result = await PlansService.getById('plan-123');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/plans/plan-123',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(result?.id).toBe('plan-123');
+    });
+
+    it('should return null for 404', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({ error: 'Plan not found' }),
+      });
+
+      const result = await PlansService.getById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('should create a plan for a district', async () => {
+      const mockDistrict = {
+        id: 'district-123',
+        slug: 'westside',
+        name: 'Westside District',
+      };
+      const newPlan = {
+        district_id: 'district-123',
+        name: 'New Strategic Plan',
+        is_public: true,
+        is_active: true,
+      };
+      const createdPlan = {
+        id: 'plan-new',
+        organization_id: 'district-123',
+        ...newPlan,
+        slug: 'new-strategic-plan',
+        order_position: 0,
+      };
+
+      // District lookup
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockDistrict),
+      });
+
+      // Create plan
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve(createdPlan),
+      });
+
+      const result = await PlansService.create(newPlan);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost/api/organizations/westside/plans',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.stringContaining('New Strategic Plan'),
+        })
+      );
+      expect(result.id).toBe('plan-new');
+    });
+
+    it('should throw error when both district_id and school_id are provided', async () => {
+      const plan = {
+        district_id: 'district-123',
+        school_id: 'school-123',
+        name: 'Invalid Plan',
+      };
+
+      await expect(PlansService.create(plan)).rejects.toThrow(
+        'Plan cannot belong to both district and school'
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when neither district_id nor school_id is provided', async () => {
+      const plan = {
+        name: 'Invalid Plan',
+      };
+
+      await expect(PlansService.create(plan)).rejects.toThrow(
+        'Plan must belong to either a district or a school'
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('should update a plan with PUT request', async () => {
+      const updatedPlan = {
+        id: 'plan-123',
+        name: 'Updated Plan Name',
+        is_public: false,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(updatedPlan),
+      });
+
+      const result = await PlansService.update('plan-123', { name: 'Updated Plan Name', is_public: false });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/plans/plan-123',
+        expect.objectContaining({
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Updated Plan Name', is_public: false }),
+        })
+      );
+      expect(result.name).toBe('Updated Plan Name');
+    });
+
+    it('should throw error on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ error: 'Database error' }),
+      });
+
+      await expect(
+        PlansService.update('plan-123', { name: 'Fail' })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a plan with DELETE request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+      });
+
+      await PlansService.delete('plan-123');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/plans/plan-123',
+        expect.objectContaining({
+          method: 'DELETE',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    it('should throw error on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({ error: 'Plan not found' }),
+      });
+
+      await expect(PlansService.delete('nonexistent')).rejects.toThrow();
+    });
+  });
+
+  describe('getActiveByDistrictSlug', () => {
+    it('should fetch active plans by district slug', async () => {
+      const mockPlans = [
+        {
+          id: 'plan-1',
+          district_id: 'district-123',
+          name: 'Active Plan',
+          slug: 'active-plan',
+          is_public: true,
+          is_active: true,
+          order_position: 0,
+        },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPlans),
+      });
+
+      const result = await PlansService.getActiveByDistrictSlug('westside');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/plans/active/westside',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].is_active).toBe(true);
+    });
+  });
+
+  describe('plan-organization association', () => {
+    it('plans fetched by district slug only return that district plans', async () => {
+      const westsidePlans = [
+        { id: 'plan-1', district_id: 'west-id', name: 'Westside Plan' },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(westsidePlans),
+      });
+
+      const result = await PlansService.getByDistrictSlug('westside');
+
+      // Verify the API was called with the correct district slug
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/organizations/westside/plans',
+        expect.any(Object)
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].district_id).toBe('west-id');
+    });
+
+    it('different districts return different plans', async () => {
+      // Fetch westside plans
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ id: 'plan-w', district_id: 'west-id', name: 'Westside Plan' }]),
+      });
+
+      const westsideResult = await PlansService.getByDistrictSlug('westside');
+      expect(westsideResult[0].id).toBe('plan-w');
+
+      // Fetch eastside plans
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ id: 'plan-e', district_id: 'east-id', name: 'Eastside Plan' }]),
+      });
+
+      const eastsideResult = await PlansService.getByDistrictSlug('eastside');
+      expect(eastsideResult[0].id).toBe('plan-e');
+
+      // Verify different API URLs were called
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost/api/organizations/westside/plans',
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost/api/organizations/eastside/plans',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('getPlansWithCounts', () => {
+    it('should fetch plans with counts via user endpoint', async () => {
+      const mockDistrict = {
+        id: 'district-123',
+        slug: 'westside',
+        name: 'Westside District',
+      };
+
+      const mockPlansWithCounts = [
+        {
+          id: 'plan-1',
+          district_id: 'district-123',
+          name: 'Plan 1',
+          objective_count: 5,
+        },
+      ];
+
+      // District lookup
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockDistrict),
+      });
+
+      // Plans with counts
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPlansWithCounts),
+      });
+
+      const result = await PlansService.getPlansWithCounts('district-123');
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost/api/user/plans-with-counts?orgSlug=westside',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/src/pages/dashboard/DashboardPlansPage.tsx
+++ b/src/pages/dashboard/DashboardPlansPage.tsx
@@ -1,0 +1,295 @@
+import { useState, useMemo } from 'react';
+import { FileText, Search, Globe, Lock, Plus, Eye } from 'lucide-react';
+import { useUserPlansWithCounts } from '../../hooks/useUserPlans';
+import { useUserDistricts } from '../../hooks/useUserDistricts';
+import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
+import type { PlanWithSummary, District } from '../../lib/types';
+
+/**
+ * DashboardPlansPage - Cross-district plans list for root domain (/dashboard/plans)
+ *
+ * Lists all plans the user has access to across all their districts.
+ * Each plan links to its district admin detail page via subdomain URL.
+ */
+export function DashboardPlansPage() {
+  const { data: plans = [], isLoading: plansLoading } = useUserPlansWithCounts();
+  const { data: districts = [], isLoading: districtsLoading } = useUserDistricts();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterType, setFilterType] = useState<string>('all');
+
+  const isLoading = plansLoading || districtsLoading;
+
+  // Build district lookup by ID for badges and navigation
+  const districtMap = useMemo(() => {
+    const map = new Map<string, District>();
+    for (const d of districts) {
+      map.set(d.id, d);
+    }
+    return map;
+  }, [districts]);
+
+  // Filter plans based on search and type
+  const filteredPlans = useMemo(() => {
+    return plans.filter(plan => {
+      const matchesSearch = plan.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (plan.type_label?.toLowerCase() || '').includes(searchQuery.toLowerCase());
+      const matchesType = filterType === 'all' || plan.type_label?.toLowerCase() === filterType.toLowerCase();
+      return matchesSearch && matchesType;
+    });
+  }, [plans, searchQuery, filterType]);
+
+  // Get unique type labels for filter dropdown
+  const typeLabels = useMemo(() => {
+    return [...new Set(plans.map(p => p.type_label).filter(Boolean))];
+  }, [plans]);
+
+  // Build link to district admin plan detail page
+  const getPlanDetailUrl = (plan: PlanWithSummary) => {
+    const district = districtMap.get(plan.district_id || '');
+    if (district) {
+      return buildSubdomainUrlWithPath('district', `/admin/plans/${plan.id}`, district.slug);
+    }
+    return `/dashboard/plans/${plan.id}`;
+  };
+
+  // Build link to district admin create page
+  const getCreatePlanUrl = () => {
+    if (districts.length === 1) {
+      return buildSubdomainUrlWithPath('district', '/admin/plans/create', districts[0].slug);
+    }
+    // For multi-district users, link to first district (they can switch)
+    if (districts.length > 0) {
+      return buildSubdomainUrlWithPath('district', '/admin/plans/create', districts[0].slug);
+    }
+    return '/dashboard/plans';
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-6 lg:p-8 space-y-6 max-w-[1100px]">
+        <div className="animate-pulse">
+          <div className="h-8 w-48 rounded" style={{ backgroundColor: 'var(--editorial-border)' }} />
+          <div className="h-4 w-64 rounded mt-2" style={{ backgroundColor: 'var(--editorial-border-light)' }} />
+        </div>
+        <div className="animate-pulse space-y-3">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="h-16 rounded-lg" style={{ backgroundColor: 'var(--editorial-border-light)' }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 lg:p-8 space-y-6 max-w-[1100px]">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1
+            className="text-2xl sm:text-[28px] font-medium tracking-tight"
+            style={{ fontFamily: "'Playfair Display', Georgia, serif", color: 'var(--editorial-text-primary)' }}
+          >
+            Strategic Plans
+          </h1>
+          <p className="text-sm mt-1" style={{ color: 'var(--editorial-text-muted)' }}>
+            View and manage all your strategic plans across districts
+          </p>
+        </div>
+        <a
+          href={getCreatePlanUrl()}
+          className="inline-flex items-center gap-2 px-4 py-2.5 text-white rounded-lg transition-colors font-semibold text-sm"
+          style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary-hover)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary)'; }}
+        >
+          <Plus size={18} />
+          New plan
+        </a>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-4">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4" style={{ color: 'var(--editorial-text-muted)' }} />
+          <input
+            type="text"
+            placeholder="Search plans..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 rounded-lg text-sm focus:outline-none"
+            style={{
+              border: '1px solid var(--editorial-border)',
+              backgroundColor: 'var(--editorial-surface)',
+              color: 'var(--editorial-text-primary)',
+            }}
+          />
+        </div>
+        {typeLabels.length > 0 && (
+          <select
+            value={filterType}
+            onChange={(e) => setFilterType(e.target.value)}
+            className="px-4 py-2 rounded-lg text-sm focus:outline-none"
+            style={{
+              border: '1px solid var(--editorial-border)',
+              backgroundColor: 'var(--editorial-surface)',
+              color: 'var(--editorial-text-primary)',
+            }}
+          >
+            <option value="all">All plans</option>
+            {typeLabels.map(label => (
+              <option key={label} value={label?.toLowerCase()}>{label}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Plans Table */}
+      <div className="rounded-xl overflow-hidden" style={{ backgroundColor: 'var(--editorial-surface)', border: '1px solid var(--editorial-border)' }}>
+        <table className="w-full">
+          <thead style={{ backgroundColor: 'var(--editorial-surface-alt)', borderBottom: '1px solid var(--editorial-border)' }}>
+            <tr>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--editorial-text-muted)' }}>
+                Plan
+              </th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--editorial-text-muted)' }}>
+                District
+              </th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--editorial-text-muted)' }}>
+                Type
+              </th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--editorial-text-muted)' }}>
+                Objectives
+              </th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--editorial-text-muted)' }}>
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredPlans.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-12 text-center">
+                  <FileText className="h-12 w-12 mx-auto mb-3" style={{ color: 'var(--editorial-border)' }} />
+                  <h3 className="text-lg font-medium mb-1" style={{ color: 'var(--editorial-text-primary)' }}>
+                    {searchQuery || filterType !== 'all' ? 'No plans match your filters' : 'No plans yet'}
+                  </h3>
+                  <p className="text-sm mb-4" style={{ color: 'var(--editorial-text-muted)' }}>
+                    {searchQuery || filterType !== 'all'
+                      ? 'Try adjusting your search or filter criteria'
+                      : 'Create your first strategic plan to organize objectives'}
+                  </p>
+                  {!searchQuery && filterType === 'all' && (
+                    <a
+                      href={getCreatePlanUrl()}
+                      className="inline-flex items-center gap-2 px-4 py-2 text-white rounded-lg transition-colors font-medium text-sm"
+                      style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
+                    >
+                      <Plus size={16} />
+                      Create your first plan
+                    </a>
+                  )}
+                </td>
+              </tr>
+            ) : (
+              filteredPlans.map((plan) => {
+                const district = districtMap.get(plan.district_id || '');
+                return (
+                  <tr
+                    key={plan.id}
+                    className="group"
+                    style={{ borderBottom: '1px solid var(--editorial-border-light)' }}
+                  >
+                    <td className="py-3 px-4">
+                      <a
+                        href={getPlanDetailUrl(plan)}
+                        className="flex items-center gap-3 text-left transition-colors"
+                      >
+                        <div
+                          className="w-9 h-9 rounded-lg flex items-center justify-center"
+                          style={{ backgroundColor: 'var(--editorial-surface-alt)', color: 'var(--editorial-text-muted)' }}
+                        >
+                          <FileText size={18} />
+                        </div>
+                        <div>
+                          <span className="font-medium" style={{ color: 'var(--editorial-text-primary)' }}>
+                            {plan.name}
+                          </span>
+                          {plan.description && (
+                            <p className="text-xs line-clamp-1 max-w-sm" style={{ color: 'var(--editorial-text-muted)' }}>
+                              {plan.description}
+                            </p>
+                          )}
+                        </div>
+                      </a>
+                    </td>
+                    <td className="py-3 px-4">
+                      {district ? (
+                        <span
+                          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                          style={{
+                            backgroundColor: district.primary_color ? `${district.primary_color}20` : 'var(--editorial-surface-alt)',
+                            color: district.primary_color || 'var(--editorial-text-secondary)',
+                          }}
+                        >
+                          {district.name}
+                        </span>
+                      ) : (
+                        <span className="text-sm" style={{ color: 'var(--editorial-text-muted)' }}>-</span>
+                      )}
+                    </td>
+                    <td className="py-3 px-4">
+                      {plan.type_label ? (
+                        <span
+                          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                          style={{ backgroundColor: 'var(--editorial-surface-alt)', color: 'var(--editorial-text-secondary)' }}
+                        >
+                          {plan.type_label}
+                        </span>
+                      ) : (
+                        <span className="text-sm" style={{ color: 'var(--editorial-text-muted)' }}>-</span>
+                      )}
+                    </td>
+                    <td className="py-3 px-4">
+                      <span className="inline-flex items-center gap-1.5 text-sm" style={{ color: 'var(--editorial-text-secondary)' }}>
+                        <Eye size={14} style={{ color: 'var(--editorial-text-muted)' }} />
+                        {plan.objectiveCount ?? 0}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4">
+                      <span
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium"
+                        style={plan.is_public
+                          ? { backgroundColor: 'rgba(107, 143, 113, 0.15)', color: 'var(--editorial-accent-success)' }
+                          : { backgroundColor: 'var(--editorial-surface-alt)', color: 'var(--editorial-text-secondary)' }
+                        }
+                      >
+                        {plan.is_public ? (
+                          <>
+                            <Globe size={12} />
+                            Public
+                          </>
+                        ) : (
+                          <>
+                            <Lock size={12} />
+                            Private
+                          </>
+                        )}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Summary */}
+      {filteredPlans.length > 0 && (
+        <p className="text-sm" style={{ color: 'var(--editorial-text-muted)' }}>
+          Showing {filteredPlans.length} of {plans.length} plans
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/dashboard/UserDashboard.tsx
+++ b/src/pages/dashboard/UserDashboard.tsx
@@ -2,10 +2,12 @@ import { useState, useMemo } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { FileText, Target, TrendingUp, ArrowRight, Plus, ChevronRight } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
-import { useUserDashboardStats } from '../../hooks/useUserDistricts';
+import { useUserDashboardStats, useUserDistricts } from '../../hooks/useUserDistricts';
 import { useUserPlansWithCounts } from '../../hooks/useUserPlans';
 import { usePlanGoals } from '../../hooks/useGoals';
+import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
 import { buildGoalHierarchy, type HierarchicalGoal, type PlanWithSummary } from '../../lib/types';
+import type { District } from '../../lib/types';
 
 export function UserDashboard() {
   const navigate = useNavigate();
@@ -17,9 +19,32 @@ export function UserDashboard() {
   const isDistrictAdmin = location.pathname.startsWith('/admin');
   const basePath = isDistrictAdmin ? '/admin' : '/dashboard';
 
-  // Fetch stats and plans
+  // Fetch stats, plans, and districts
   const { data: stats, isLoading: statsLoading } = useUserDashboardStats();
   const { data: plans = [], isLoading: plansLoading } = useUserPlansWithCounts();
+  const { data: districts = [] } = useUserDistricts();
+
+  // Build district lookup for cross-domain navigation on root domain
+  const districtMap = useMemo(() => {
+    const map = new Map<string, District>();
+    for (const d of districts) {
+      map.set(d.id, d);
+    }
+    return map;
+  }, [districts]);
+
+  // Navigate to district admin page (cross-domain on root, in-app on district admin)
+  const navigateToDistrictAdmin = (path: string, districtId?: string | null) => {
+    if (isDistrictAdmin) {
+      navigate(path);
+      return;
+    }
+    // Root domain: redirect to district subdomain
+    const district = districtId ? districtMap.get(districtId) : districts[0];
+    if (district) {
+      window.location.href = buildSubdomainUrlWithPath('district', path, district.slug);
+    }
+  };
 
   // Fetch goals for the first plan to show in tree view
   const planIds = plans.map((p) => p.id);
@@ -108,7 +133,7 @@ export function UserDashboard() {
               <ArrowRight size={14} />
             </Link>
             <button
-              onClick={() => navigate(`${basePath}/plans/create`)}
+              onClick={() => navigateToDistrictAdmin('/admin/plans/create')}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-white rounded-lg transition-colors font-medium text-sm"
               style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
               onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary-hover)'; }}
@@ -144,7 +169,7 @@ export function UserDashboard() {
               Create your first strategic plan to organize your objectives.
             </p>
             <button
-              onClick={() => navigate(`${basePath}/plans/create`)}
+              onClick={() => navigateToDistrictAdmin('/admin/plans/create')}
               className="inline-flex items-center gap-2 px-4 py-2.5 text-white rounded-lg font-semibold text-sm"
               style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
             >
@@ -161,6 +186,7 @@ export function UserDashboard() {
                 basePath={basePath}
                 isSelected={selectedPlanId === plan.id}
                 onClick={() => setSelectedPlanId(plan.id)}
+                onNavigateDetail={() => navigateToDistrictAdmin(`/admin/plans/${plan.id}`, plan.district_id)}
               />
             ))}
           </div>
@@ -239,14 +265,13 @@ function StatCard({ label, value, icon, hidden }: { label: string; value: string
   );
 }
 
-function PlanRow({ plan, basePath, isSelected, onClick }: {
+function PlanRow({ plan, isSelected, onClick, onNavigateDetail }: {
   plan: PlanWithSummary;
   basePath: string;
   isSelected: boolean;
   onClick: () => void;
+  onNavigateDetail: () => void;
 }) {
-  const navigate = useNavigate();
-
   return (
     <div
       className="rounded-xl px-5 py-4 flex items-center justify-between cursor-pointer transition-all"
@@ -291,7 +316,7 @@ function PlanRow({ plan, basePath, isSelected, onClick }: {
       <button
         onClick={(e) => {
           e.stopPropagation();
-          navigate(`${basePath}/plans/${plan.id}`);
+          onNavigateDetail();
         }}
         className="p-2 rounded-lg transition-colors"
         style={{ color: 'var(--editorial-text-muted)' }}

--- a/src/pages/dashboard/index.ts
+++ b/src/pages/dashboard/index.ts
@@ -1,2 +1,3 @@
 export { UserDashboard } from './UserDashboard';
 export { PlaceholderPage } from './PlaceholderPage';
+export { DashboardPlansPage } from './DashboardPlansPage';

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -5,7 +5,7 @@ import { DistrictRedirect } from '../components/DistrictRedirect';
 import { AccountSettings } from '../pages/AccountSettings';
 import { AboutPage, PrivacyPage, TermsPage } from '../pages/legal';
 import { DashboardLayout } from '../layouts/DashboardLayout';
-import { UserDashboard, PlaceholderPage } from '../pages/dashboard';
+import { UserDashboard, PlaceholderPage, DashboardPlansPage } from '../pages/dashboard';
 import { useAuth } from '../contexts/AuthContext';
 
 // Public District Layout and Pages
@@ -57,11 +57,8 @@ export function RootRouter() {
         }
       >
         <Route index element={<UserDashboard />} />
-        <Route path="plans" element={<PlaceholderPage title="Strategic Plans" description="View and manage all your strategic plans in one place." />} />
-        <Route path="plans/new" element={<PlaceholderPage title="Create New Plan" description="Create a new strategic plan for your organization." />} />
-        <Route path="plans/create" element={<PlaceholderPage title="Create New Plan" description="Create a new strategic plan for your organization." />} />
-        <Route path="plans/:planId" element={<PlaceholderPage title="Plan Details" description="View and manage your strategic plan details." />} />
-        <Route path="plans/:planId/objectives/new" element={<PlaceholderPage title="Add New Objective" description="Add a new objective to your strategic plan." />} />
+        <Route path="plans" element={<DashboardPlansPage />} />
+        <Route path="plans/:planId" element={<DashboardPlansPage />} />
         <Route path="objectives" element={<PlaceholderPage title="Objectives & Goals" description="Track and manage your strategic objectives and goals." />} />
         <Route path="objectives/create" element={<PlaceholderPage title="Create Objective" description="Create a new objective for your strategic plan." />} />
         <Route path="objectives/:objectiveId" element={<PlaceholderPage title="Objective Details" description="View and edit objective details." />} />

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -58,7 +58,7 @@ export function RootRouter() {
       >
         <Route index element={<UserDashboard />} />
         <Route path="plans" element={<DashboardPlansPage />} />
-        <Route path="plans/:planId" element={<DashboardPlansPage />} />
+        <Route path="plans/*" element={<DashboardPlansPage />} />
         <Route path="objectives" element={<PlaceholderPage title="Objectives & Goals" description="Track and manage your strategic objectives and goals." />} />
         <Route path="objectives/create" element={<PlaceholderPage title="Create Objective" description="Create a new objective for your strategic plan." />} />
         <Route path="objectives/:objectiveId" element={<PlaceholderPage title="Objective Details" description="View and edit objective details." />} />


### PR DESCRIPTION
## Summary

- **Fix broken "Strategic Plans" sidebar link** — clicking it on the root domain dashboard (`/dashboard/plans`) previously showed a placeholder stub; now renders a fully functional plans list
- **New `DashboardPlansPage` component** that lists plans across all user districts with district badges, search/filter, type labels, objective counts, and public/private status
- **Each plan links to its district admin detail page** via `buildSubdomainUrlWithPath()` (handles localhost, lvh.me, Vercel preview, and production subdomain URLs)
- **17 new PlansService unit tests** covering CRUD operations, plan-organization association, and error paths
- **Playwright E2E tests** for sidebar navigation, plan list rendering, search filtering, and district scoping

## Files Changed

| File | Change |
|------|--------|
| `src/routers/RootRouter.tsx` | Replace 5 PlaceholderPage stubs with DashboardPlansPage |
| `src/pages/dashboard/DashboardPlansPage.tsx` | New cross-district plans list component |
| `src/pages/dashboard/index.ts` | Export new page |
| `src/lib/services/__tests__/plans.service.test.ts` | 17 new unit tests |
| `e2e/admin/strategic-plans.spec.ts` | Playwright E2E tests |

## Test plan

- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 new errors on changed files
- [x] `npm run build` — succeeds
- [x] `npm run test:run` — 683/683 tests pass (17 new)
- [x] Manual smoke test: `/dashboard` → click "Strategic Plans" → plans list renders → click plan → navigates to district admin detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strategic Plans dashboard for viewing and managing cross-district plans
  * Search and plan-type filters; display of district, objective count, and publication status
  * District-aware navigation for creating and opening plan details (handles cross-domain routing)
  * Consolidated plans view/route under the dashboard

* **Tests**
  * Added end-to-end tests covering root and district-admin plan flows
  * Added comprehensive unit tests for plan service behaviors and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->