### PR TITLE
fix: resolve admin dashboard crash from missing user_id

### DIFF
--- a/api/admin/recent-users.ts
+++ b/api/admin/recent-users.ts
@@ -1,12 +1,13 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "../lib/db.js";
 import { user } from "../lib/schema/index.js";
+import { organizations, organizationMembers } from "../lib/schema/index.js";
 import { requireSystemAdmin } from "../lib/middleware/auth.js";
 import { jsonOk, jsonError } from "../lib/response.js";
 
 /**
  * GET /api/admin/recent-users
- * Get recent users. Requires system admin.
+ * Get recent users with their org membership info. Requires system admin.
  */
 export async function GET(req: Request) {
   try {
@@ -18,23 +19,50 @@ export async function GET(req: Request) {
       100,
     );
 
-    const users = await db
-      .select()
+    // Fetch recent users with their first org membership
+    const rows = await db
+      .select({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        image: user.image,
+        isSystemAdmin: user.isSystemAdmin,
+        createdAt: user.createdAt,
+        memberRole: organizationMembers.role,
+        orgName: organizations.name,
+      })
       .from(user)
+      .leftJoin(organizationMembers, eq(user.id, organizationMembers.userId))
+      .leftJoin(
+        organizations,
+        eq(organizationMembers.organizationId, organizations.id),
+      )
       .orderBy(desc(user.createdAt))
       .limit(limit);
 
-    return jsonOk(
-      users.map((u) => ({
-        id: u.id,
-        email: u.email,
-        name: u.name,
-        image: u.image,
-        is_system_admin: u.isSystemAdmin,
-        created_at: u.createdAt,
-        updated_at: u.updatedAt,
-      })),
-    );
+    // Deduplicate users who have multiple memberships (keep first row)
+    const seen = new Set<string>();
+    const result = [];
+    for (const row of rows) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+
+      const role = row.isSystemAdmin
+        ? "system_admin"
+        : row.memberRole ?? "viewer";
+
+      result.push({
+        id: row.id,
+        user_id: row.id,
+        name: row.name,
+        email: row.email,
+        role,
+        district_name: row.orgName ?? undefined,
+        created_at: row.createdAt,
+      });
+    }
+
+    return jsonOk(result);
   } catch (error) {
     if (error instanceof Response) return error;
     return jsonError(

--- a/src/components/admin/dashboard/RecentUsersTable.tsx
+++ b/src/components/admin/dashboard/RecentUsersTable.tsx
@@ -60,9 +60,9 @@ export function RecentUsersTable({ users, isLoading }: RecentUsersTableProps) {
                       <User className="h-4 w-4 text-[#8a8a8a]" />
                     </div>
                     <div className="min-w-0">
-                      <code className="text-xs text-[#4a4a4a] font-mono truncate block">
-                        {user.user_id.slice(0, 8)}...
-                      </code>
+                      <span className="text-sm font-medium text-[#1a1a1a] truncate block">
+                        {user.name || user.email || user.user_id?.slice(0, 8) || user.id.slice(0, 8)}
+                      </span>
                     </div>
                   </div>
                 </td>

--- a/src/lib/services/systemAdmin.service.ts
+++ b/src/lib/services/systemAdmin.service.ts
@@ -27,6 +27,8 @@ export type UserRole = 'system_admin' | 'district_admin' | 'school_admin' | 'edi
 export interface UserWithRole {
   id: string;
   user_id: string;
+  name?: string;
+  email?: string;
   role: UserRole;
   district_name?: string;
   district_slug?: string;

--- a/src/pages/admin/SystemDashboard.tsx
+++ b/src/pages/admin/SystemDashboard.tsx
@@ -218,9 +218,9 @@ export function SystemDashboard() {
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <code className="text-xs text-[#4a4a4a] font-mono">
-                      {user.user_id.slice(0, 8)}...
-                    </code>
+                    <span className="text-sm font-medium text-[#1a1a1a] truncate">
+                      {user.name || user.email || user.user_id?.slice(0, 8) || user.id.slice(0, 8)}
+                    </span>
                     <UserRoleBadge role={user.role} />
                   </div>
                   <p className="text-xs text-[#8a8a8a] mt-0.5">


### PR DESCRIPTION
## Summary
- **Bug**: System admin dashboard at `admin.stratadash.org` crashed with `TypeError: undefined is not an object (evaluating 's.user_id.slice')` after PR #139
- **Root cause**: The `GET /api/admin/recent-users` endpoint returned `{id}` but the frontend accessed `user.user_id.slice(0, 8)`, which was `undefined`
- **Fix**: Updated the API to join `organization_members`/`organizations` so the response includes `user_id`, `role`, and `district_name` matching the `UserWithRole` interface. Also added optional chaining in frontend components as a safety net, and improved display to show user name/email instead of truncated UUIDs.

## Test plan
- [x] TypeScript type-check passes
- [x] All 684 unit tests pass
- [x] Production build succeeds
- [ ] Verify admin dashboard loads at `admin.stratadash.org` after deploy
- [ ] Verify recent users section displays names and role badges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced user identification in admin dashboard—Recent Users table now displays user names and emails for better recognition, with fallback to truncated IDs.
  * Backend now retrieves comprehensive organization membership information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->