### PR TITLE
feat(admin): district table CRUD + wildcard DNS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/.env.staging
 **/.env.production
 **/.env.*.local
+**/.env.test
 **/.env*-backup
 **/.env*.backup
 

--- a/e2e/admin/district-crud.spec.ts
+++ b/e2e/admin/district-crud.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * District CRUD Operations E2E Tests
+ *
+ * Tests the district management table on the System Admin Districts page.
+ * Covers table rendering, search filtering, status filtering, sorting,
+ * edit modal, and delete confirmation dialog.
+ *
+ * These tests use `test.describe.serial` because they depend on page state
+ * established in earlier tests (e.g., verifying the table exists before
+ * testing filters against it).
+ *
+ * Prerequisites:
+ * 1. System admin test credentials configured in .env.test
+ * 2. At least two seeded districts (Westside, Eastside) in the database
+ *
+ * To run: npx playwright test e2e/admin/district-crud.spec.ts
+ */
+
+const shouldSkipAuthTests = !process.env.TEST_SYSTEM_ADMIN_EMAIL;
+
+/**
+ * Helper function to login as system admin.
+ * Requires TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD environment variables.
+ */
+async function loginAsSystemAdmin(page: any) {
+  const email = process.env.TEST_SYSTEM_ADMIN_EMAIL;
+  const password = process.env.TEST_SYSTEM_ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'System admin test credentials not configured. ' +
+      'Set TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD in .env.test'
+    );
+  }
+
+  // Navigate to login page with admin subdomain
+  await page.goto('/login?subdomain=admin');
+
+  // Fill in credentials
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+
+  // Submit form
+  await page.locator('button[type="submit"]').click();
+
+  // Wait for navigation to admin dashboard
+  await page.waitForURL(/\?subdomain=admin/, { timeout: 10000 });
+}
+
+test.describe.serial('District CRUD Operations', () => {
+  test.skip(shouldSkipAuthTests, 'requires test credentials');
+
+  test.afterEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test('should navigate to districts page and verify table renders', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+
+    // Navigate to districts page
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Verify the Districts heading is visible
+    await expect(page.getByRole('heading', { name: /Districts/i })).toBeVisible();
+
+    // Verify the table renders with at least one row
+    await expect(page.locator('table')).toBeVisible();
+    await expect(page.locator('tbody tr').first()).toBeVisible();
+
+    // Verify the "Add District" button exists
+    await expect(page.getByRole('link', { name: /Add District/i })).toBeVisible();
+  });
+
+  test('should filter districts by search term', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Type a search term
+    const searchInput = page.locator('input[placeholder*="Search"]');
+    await searchInput.fill('westside');
+
+    // Wait for filtering to apply
+    await page.waitForTimeout(300);
+
+    // Should show Westside and not show other districts
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+    await expect(page.locator('tbody').getByText('Westside')).toBeVisible();
+
+    // Clear search
+    await searchInput.clear();
+    await page.waitForTimeout(300);
+
+    // Should show all districts again
+    const rowCount = await page.locator('tbody tr').count();
+    expect(rowCount).toBeGreaterThanOrEqual(2); // At least Westside and Eastside
+  });
+
+  test('should filter districts by status', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Get initial count
+    const initialCount = await page.locator('tbody tr').count();
+
+    // Click "Active" filter
+    await page.locator('select').selectOption('active');
+    await page.waitForTimeout(300);
+
+    // All visible districts should have "Active" badge
+    const rows = page.locator('tbody tr');
+    const activeCount = await rows.count();
+    for (let i = 0; i < activeCount; i++) {
+      await expect(rows.nth(i).getByText('Active')).toBeVisible();
+    }
+
+    // Reset to All
+    await page.locator('select').selectOption('all');
+    await page.waitForTimeout(300);
+    expect(await page.locator('tbody tr').count()).toBe(initialCount);
+  });
+
+  test('should sort districts by name', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Click the "District" column header to sort
+    await page.locator('thead th').first().click();
+    await page.waitForTimeout(300);
+
+    // Get first row name
+    const firstNameAsc = await page.locator('tbody tr').first().locator('td').first().textContent();
+
+    // Click again to reverse sort
+    await page.locator('thead th').first().click();
+    await page.waitForTimeout(300);
+
+    const firstNameDesc = await page.locator('tbody tr').first().locator('td').first().textContent();
+
+    // Names should be different (assuming more than 1 district)
+    expect(firstNameAsc).not.toBe(firstNameDesc);
+  });
+
+  test('should open edit modal from actions menu', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Click the first row's actions button (3-dot menu)
+    await page.locator('tbody tr').first().locator('button[aria-label="Actions"]').click();
+
+    // Click "Edit District" from dropdown
+    await page.getByText('Edit District').click();
+
+    // Verify edit modal opens
+    await expect(page.getByText('Edit District').first()).toBeVisible();
+
+    // Verify form is pre-filled
+    const nameInput = page.locator('input').first();
+    const nameValue = await nameInput.inputValue();
+    expect(nameValue.length).toBeGreaterThan(0);
+
+    // Close modal
+    await page.locator('button').filter({ hasText: 'Cancel' }).click();
+
+    // Modal should be closed
+    await expect(page.locator('.fixed.inset-0')).not.toBeVisible();
+  });
+
+  test('should open delete confirmation from actions menu', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Click the first row's actions button
+    await page.locator('tbody tr').first().locator('button[aria-label="Actions"]').click();
+
+    // Click "Delete District"
+    await page.getByText('Delete District').click();
+
+    // Verify delete confirmation modal opens
+    await expect(page.getByText('Delete District').first()).toBeVisible();
+    await expect(page.getByText(/permanently delete/i)).toBeVisible();
+
+    // The delete button should be disabled initially
+    const deleteButton = page.locator('button').filter({ hasText: /^Delete District$/ });
+    await expect(deleteButton).toBeDisabled();
+
+    // Close modal by clicking Cancel
+    await page.locator('button').filter({ hasText: 'Cancel' }).click();
+  });
+});

--- a/e2e/admin/district-routes.spec.ts
+++ b/e2e/admin/district-routes.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * District Routing Parity E2E Tests
+ *
+ * Verifies that both seeded districts (Westside and Eastside) have working
+ * routes for public pages, admin dashboards, and appear correctly in the
+ * system admin districts table and district switcher.
+ *
+ * Uses the ?subdomain= query param to simulate subdomain routing in local dev.
+ *
+ * Prerequisites:
+ * 1. System admin test credentials configured in .env.test
+ * 2. At least two seeded districts (Westside, Eastside) in the database
+ *
+ * To run: npx playwright test e2e/admin/district-routes.spec.ts
+ */
+
+const shouldSkipAuthTests = !process.env.TEST_SYSTEM_ADMIN_EMAIL;
+
+/**
+ * Helper function to login as system admin.
+ * Requires TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD environment variables.
+ */
+async function loginAsSystemAdmin(page: any) {
+  const email = process.env.TEST_SYSTEM_ADMIN_EMAIL;
+  const password = process.env.TEST_SYSTEM_ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'System admin test credentials not configured. ' +
+      'Set TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD in .env.test'
+    );
+  }
+
+  // Navigate to login page with admin subdomain
+  await page.goto('/login?subdomain=admin');
+
+  // Fill in credentials
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+
+  // Submit form
+  await page.locator('button[type="submit"]').click();
+
+  // Wait for navigation to admin dashboard
+  await page.waitForURL(/\?subdomain=admin/, { timeout: 10000 });
+}
+
+test.describe('District Routing Parity', () => {
+  test.skip(shouldSkipAuthTests, 'requires test credentials');
+
+  test.afterEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test('Westside public page loads', async ({ page }) => {
+    await page.goto('/?subdomain=westside');
+    await page.waitForLoadState('networkidle');
+
+    // Should show some content (not an error page)
+    await expect(page.locator('body')).not.toHaveText(/404|not found/i);
+  });
+
+  test('Eastside public page loads', async ({ page }) => {
+    await page.goto('/?subdomain=eastside');
+    await page.waitForLoadState('networkidle');
+
+    // Should show some content (not an error page)
+    await expect(page.locator('body')).not.toHaveText(/404|not found/i);
+  });
+
+  test('Westside admin dashboard loads after login', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/admin?subdomain=westside');
+    await page.waitForLoadState('networkidle');
+
+    // Should show admin content, not redirect to login
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('Eastside admin dashboard loads after login', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/admin?subdomain=eastside');
+    await page.waitForLoadState('networkidle');
+
+    // Should show admin content, not redirect to login
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('Both districts appear in system admin districts table', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/districts?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Verify the table is visible
+    await expect(page.locator('table')).toBeVisible();
+
+    // Both districts should appear in the table body
+    await expect(page.locator('tbody').getByText('westside')).toBeVisible();
+    await expect(page.locator('tbody').getByText('eastside')).toBeVisible();
+  });
+
+  test('District switcher shows both districts', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+
+    // Navigate to a district admin page first
+    await page.goto('/admin?subdomain=westside');
+    await page.waitForLoadState('networkidle');
+
+    // Look for district switcher (may be in sidebar or header)
+    const switcher = page.locator('[data-testid="district-switcher"], [aria-label*="switch"], [aria-label*="district"]');
+    if (await switcher.isVisible()) {
+      await switcher.click();
+
+      // Should show both districts in dropdown
+      await expect(page.getByText(/westside/i)).toBeVisible();
+      await expect(page.getByText(/eastside/i)).toBeVisible();
+    }
+  });
+});

--- a/e2e/auth/district-auth.spec.ts
+++ b/e2e/auth/district-auth.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Auth Across Districts E2E Tests
+ *
+ * Verifies that authentication works correctly across the admin subdomain,
+ * Westside, and Eastside district subdomains. Tests that system admin
+ * credentials grant access to all subdomains, unauthenticated users are
+ * redirected to login, and sessions persist when switching between districts.
+ *
+ * Uses the ?subdomain= query param to simulate subdomain routing in local dev.
+ *
+ * Prerequisites:
+ * 1. System admin test credentials configured in .env.test
+ * 2. At least two seeded districts (Westside, Eastside) in the database
+ *
+ * To run: npx playwright test e2e/auth/district-auth.spec.ts
+ */
+
+const shouldSkipAuthTests = !process.env.TEST_SYSTEM_ADMIN_EMAIL;
+
+/**
+ * Helper function to login as system admin.
+ * Requires TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD environment variables.
+ */
+async function loginAsSystemAdmin(page: any) {
+  const email = process.env.TEST_SYSTEM_ADMIN_EMAIL;
+  const password = process.env.TEST_SYSTEM_ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'System admin test credentials not configured. ' +
+      'Set TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD in .env.test'
+    );
+  }
+
+  // Navigate to login page with admin subdomain
+  await page.goto('/login?subdomain=admin');
+
+  // Fill in credentials
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+
+  // Submit form
+  await page.locator('button[type="submit"]').click();
+
+  // Wait for navigation to admin dashboard
+  await page.waitForURL(/\?subdomain=admin/, { timeout: 10000 });
+}
+
+test.describe('Auth Across Districts', () => {
+  test.skip(shouldSkipAuthTests, 'requires test credentials');
+
+  test.afterEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test('System admin can access admin subdomain', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+
+    // Should show System Administration page, not login
+    await expect(page.getByText('System Administration')).toBeVisible();
+  });
+
+  test('System admin can access Westside admin', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/admin?subdomain=westside');
+    await page.waitForLoadState('networkidle');
+
+    // Should not redirect to login
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('System admin can access Eastside admin', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+    await page.goto('/admin?subdomain=eastside');
+    await page.waitForLoadState('networkidle');
+
+    // Should not redirect to login
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('Unauthenticated user redirected to login on admin routes', async ({ page }) => {
+    // Clear any existing cookies
+    await page.context().clearCookies();
+
+    await page.goto('/?subdomain=admin');
+
+    // Should redirect to login
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+  });
+
+  test('Session persists when switching between districts', async ({ page }) => {
+    await loginAsSystemAdmin(page);
+
+    // Access Westside admin
+    await page.goto('/admin?subdomain=westside');
+    await page.waitForLoadState('networkidle');
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // Switch to Eastside admin (same session)
+    await page.goto('/admin?subdomain=eastside');
+    await page.waitForLoadState('networkidle');
+
+    // Should still be authenticated
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // Go back to system admin
+    await page.goto('/?subdomain=admin');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('System Administration')).toBeVisible();
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -6,24 +6,36 @@ import { LoginPage } from '../helpers/login-page';
  *
  * Extends Playwright's base test with authentication capabilities.
  * Automatically handles login state management across tests.
+ *
+ * - `loginPage`: A LoginPage page-object instance for manual login flows
+ * - `authenticatedPage`: A Page that is pre-authenticated as the system admin
+ *   (requires TEST_SYSTEM_ADMIN_EMAIL and TEST_SYSTEM_ADMIN_PASSWORD env vars)
  */
 
 export const test = base.extend<{
   loginPage: LoginPage;
   authenticatedPage: Page;
 }>({
-   
   loginPage: async ({ page }, use) => {
     const loginPage = new LoginPage(page);
     await use(loginPage);
   },
 
-   
   authenticatedPage: async ({ page }, use) => {
-    // TODO: Add authentication logic here
-    // For now, pass through the page
-    // We'll implement this once we understand the auth flow better
+    const email = process.env.TEST_SYSTEM_ADMIN_EMAIL;
+    const password = process.env.TEST_SYSTEM_ADMIN_PASSWORD;
+
+    if (email && password) {
+      const loginPage = new LoginPage(page);
+      await loginPage.goto();
+      await loginPage.login(email, password);
+      await loginPage.expectLoginSuccess();
+    }
+
     await use(page);
+
+    // Cleanup: clear auth state after test
+    await page.context().clearCookies();
   },
 });
 

--- a/src/components/admin/DistrictFormModal.tsx
+++ b/src/components/admin/DistrictFormModal.tsx
@@ -17,7 +17,10 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
     slug: district?.slug || '',
     tagline: district?.tagline || '',
     primary_color: district?.primary_color || '#C03537',
+    secondary_color: district?.secondary_color || '#c9a227',
     logo_url: district?.logo_url || '',
+    admin_email: district?.admin_email || '',
+    is_public: district?.is_public ?? true,
   });
   const [error, setError] = useState('');
 
@@ -60,25 +63,25 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-card border border-border rounded-lg p-6 max-w-md w-full mx-4">
+      <div className="bg-white border border-[#e8e6e1] rounded-lg p-6 max-w-md w-full mx-4">
         <div className="flex items-center justify-between mb-6">
-          <h3 className="text-lg font-semibold text-foreground">
+          <h3 className="text-lg font-semibold text-[#1a1a1a]">
             {district ? 'Edit District' : 'Create New District'}
           </h3>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+          <button onClick={onClose} className="text-[#8a8a8a] hover:text-[#1a1a1a]">
             <X className="h-5 w-5" />
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
-            <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 text-sm text-destructive">
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
               {error}
             </div>
           )}
 
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">
               District Name *
             </label>
             <Input
@@ -89,19 +92,19 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Slug *</label>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Slug *</label>
             <Input
               value={formData.slug}
               onChange={(e) => setFormData((prev) => ({ ...prev, slug: e.target.value }))}
               placeholder="westside"
             />
-            <p className="text-xs text-muted-foreground mt-1">
-              URL: {formData.slug || 'district'}.stratadash.org
+            <p className="text-xs text-[#8a8a8a] mt-1">
+              URL: https://{formData.slug || 'district'}.stratadash.org
             </p>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Tagline</label>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Tagline</label>
             <Input
               value={formData.tagline}
               onChange={(e) => setFormData((prev) => ({ ...prev, tagline: e.target.value }))}
@@ -110,7 +113,7 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Primary Color</label>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Primary Color</label>
             <div className="flex items-center gap-3">
               <input
                 type="color"
@@ -118,7 +121,7 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, primary_color: e.target.value }))
                 }
-                className="w-10 h-10 rounded border border-border cursor-pointer"
+                className="w-10 h-10 rounded border border-[#e8e6e1] cursor-pointer"
               />
               <Input
                 value={formData.primary_color}
@@ -132,12 +135,66 @@ export function DistrictFormModal({ district, onClose, onSubmit, isLoading }: Di
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Logo URL</label>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Secondary Color</label>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                value={formData.secondary_color}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, secondary_color: e.target.value }))
+                }
+                className="w-10 h-10 rounded border border-[#e8e6e1] cursor-pointer"
+              />
+              <Input
+                value={formData.secondary_color}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, secondary_color: e.target.value }))
+                }
+                placeholder="#c9a227"
+                className="flex-1"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Logo URL</label>
             <Input
               value={formData.logo_url}
               onChange={(e) => setFormData((prev) => ({ ...prev, logo_url: e.target.value }))}
               placeholder="https://example.com/logo.png"
             />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Admin Email</label>
+            <Input
+              type="email"
+              value={formData.admin_email}
+              onChange={(e) => setFormData((prev) => ({ ...prev, admin_email: e.target.value }))}
+              placeholder="admin@district.org"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-[#1a1a1a] mb-1">Status</label>
+            <div className="flex items-center">
+              <button
+                type="button"
+                onClick={() => setFormData((prev) => ({ ...prev, is_public: !prev.is_public }))}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  formData.is_public ? 'bg-green-500' : 'bg-gray-300'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    formData.is_public ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+              <span className="ml-3 text-sm text-[#8a8a8a]">
+                {formData.is_public ? 'Active' : 'Inactive'}
+              </span>
+            </div>
           </div>
 
           <div className="flex justify-end gap-2 pt-4">

--- a/src/pages/admin/DistrictsPage.tsx
+++ b/src/pages/admin/DistrictsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Search,
@@ -7,122 +7,127 @@ import {
   Target,
   GraduationCap,
   Users,
-  ExternalLink,
-  Eye,
   Loader2,
+  MoreVertical,
+  ChevronUp,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
 } from 'lucide-react';
 import { useDistrictsWithStats } from '../../hooks/useSystemAdminStats';
+import { useUpdateDistrict, useDeleteDistrict } from '../../hooks/useDistricts';
+import { useQueryClient } from '@tanstack/react-query';
 import { buildSubdomainUrlWithPath } from '../../lib/subdomain';
+import { DistrictFormModal } from '../../components/admin/DistrictFormModal';
+import { DistrictActionsMenu } from '../../components/admin/DistrictActionsMenu';
 import type { DistrictWithStats } from '../../lib/services/systemAdmin.service';
+import type { District } from '../../lib/types';
 
-function DistrictCardItem({ district }: { district: DistrictWithStats }) {
-  const publicUrl = buildSubdomainUrlWithPath('district', '', district.slug);
-  const adminUrl = buildSubdomainUrlWithPath('district', '/admin', district.slug);
-
-  return (
-    <div className="bg-white border border-[#e8e6e1] rounded-xl overflow-hidden hover:shadow-lg transition-all group">
-      {/* Color accent stripe */}
-      <div
-        className="h-1.5"
-        style={{ backgroundColor: district.primary_color || '#c9a227' }}
-      />
-
-      <div className="p-5">
-        {/* Header: Logo + Name */}
-        <div className="flex items-start gap-3 mb-4">
-          {district.logo_url ? (
-            <img
-              src={district.logo_url}
-              alt=""
-              className="w-11 h-11 rounded-lg object-cover flex-shrink-0"
-            />
-          ) : (
-            <div
-              className="w-11 h-11 rounded-lg flex items-center justify-center text-white text-base font-bold flex-shrink-0"
-              style={{ backgroundColor: district.primary_color || '#c9a227' }}
-            >
-              {district.name.charAt(0)}
-            </div>
-          )}
-          <div className="min-w-0 flex-1">
-            <h3 className="text-sm font-semibold text-[#1a1a1a] truncate">
-              {district.name}
-            </h3>
-            <code className="text-xs text-[#8a8a8a]">{district.slug}</code>
-          </div>
-          <span
-            className={`px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${
-              district.is_public
-                ? 'bg-green-100 text-green-700'
-                : 'bg-gray-100 text-gray-600'
-            }`}
-          >
-            {district.is_public ? 'Active' : 'Inactive'}
-          </span>
-        </div>
-
-        {district.tagline && (
-          <p className="text-xs text-[#8a8a8a] mb-4 line-clamp-2">
-            {district.tagline}
-          </p>
-        )}
-
-        {/* Stats */}
-        <div className="flex items-center gap-4 mb-4 pb-4 border-b border-[#e8e6e1]">
-          <div className="flex items-center gap-1.5">
-            <Target className="h-3.5 w-3.5 text-[#8a8a8a]" />
-            <span className="text-sm font-medium text-[#1a1a1a]">
-              {district.goals_count}
-            </span>
-            <span className="text-xs text-[#8a8a8a]">goals</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <GraduationCap className="h-3.5 w-3.5 text-[#8a8a8a]" />
-            <span className="text-sm font-medium text-[#1a1a1a]">
-              {district.schools_count}
-            </span>
-            <span className="text-xs text-[#8a8a8a]">schools</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Users className="h-3.5 w-3.5 text-[#8a8a8a]" />
-            <span className="text-sm font-medium text-[#1a1a1a]">
-              {district.users_count}
-            </span>
-            <span className="text-xs text-[#8a8a8a]">users</span>
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center justify-end gap-2">
-          <button
-            onClick={() => window.open(publicUrl, '_blank')}
-            className="w-8 h-8 rounded-lg hover:bg-[#f5f3ef] text-[#8a8a8a] hover:text-[#4a4a4a] flex items-center justify-center transition-colors"
-            title="Preview public site"
-          >
-            <Eye className="h-4 w-4" />
-          </button>
-          <a
-            href={adminUrl}
-            className="w-8 h-8 rounded-lg hover:bg-[#f5f3ef] text-[#8a8a8a] hover:text-[#4a4a4a] flex items-center justify-center transition-colors"
-            title="Open district admin"
-          >
-            <ExternalLink className="h-4 w-4" />
-          </a>
-        </div>
-      </div>
-    </div>
-  );
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 30) return `${diffDays} days ago`;
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths === 1) return '1 month ago';
+  if (diffMonths < 12) return `${diffMonths} months ago`;
+  const diffYears = Math.floor(diffMonths / 12);
+  if (diffYears === 1) return '1 year ago';
+  return `${diffYears} years ago`;
 }
+
+type SortField = 'name' | 'status' | 'created_at';
+type SortDirection = 'asc' | 'desc';
+type StatusFilter = 'all' | 'active' | 'inactive';
+const PAGE_SIZE = 25;
 
 export function DistrictsPage() {
   const [searchTerm, setSearchTerm] = useState('');
-  const { data: districts = [], isLoading, error } = useDistrictsWithStats();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sortField, setSortField] = useState<SortField>('name');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [editingDistrict, setEditingDistrict] = useState<DistrictWithStats | null>(null);
+  const [deletingDistrict, setDeletingDistrict] = useState<DistrictWithStats | null>(null);
+  const [deleteConfirmSlug, setDeleteConfirmSlug] = useState('');
+  const [activeMenu, setActiveMenu] = useState<string | null>(null);
 
-  const filteredDistricts = districts.filter(
-    (d) =>
-      d.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      d.slug.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const queryClient = useQueryClient();
+  const { data: districts = [], isLoading, error } = useDistrictsWithStats();
+  const updateDistrict = useUpdateDistrict();
+  const deleteDistrict = useDeleteDistrict();
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+    setCurrentPage(1);
+  };
+
+  const filtered = useMemo(() => {
+    const result = districts.filter((d) => {
+      const matchesSearch =
+        !searchTerm ||
+        d.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        d.slug.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesStatus =
+        statusFilter === 'all' ||
+        (statusFilter === 'active' && d.is_public) ||
+        (statusFilter === 'inactive' && !d.is_public);
+      return matchesSearch && matchesStatus;
+    });
+
+    result.sort((a, b) => {
+      const dir = sortDirection === 'asc' ? 1 : -1;
+      if (sortField === 'name') return a.name.localeCompare(b.name) * dir;
+      if (sortField === 'status') return (Number(a.is_public) - Number(b.is_public)) * dir;
+      if (sortField === 'created_at')
+        return (new Date(a.created_at).getTime() - new Date(b.created_at).getTime()) * dir;
+      return 0;
+    });
+
+    return result;
+  }, [districts, searchTerm, statusFilter, sortField, sortDirection]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const paginated = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const rangeStart = filtered.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(currentPage * PAGE_SIZE, filtered.length);
+
+  const handleEditSubmit = async (data: Partial<District>) => {
+    if (!editingDistrict) return;
+    await updateDistrict.mutateAsync({ id: editingDistrict.id, updates: data });
+    queryClient.invalidateQueries({ queryKey: ['system-admin', 'districts-with-stats'] });
+    setEditingDistrict(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deletingDistrict) return;
+    await deleteDistrict.mutateAsync(deletingDistrict.id);
+    queryClient.invalidateQueries({ queryKey: ['system-admin', 'districts-with-stats'] });
+    setDeletingDistrict(null);
+    setDeleteConfirmSlug('');
+  };
+
+  const handleRowClick = (district: DistrictWithStats) => {
+    const adminUrl = buildSubdomainUrlWithPath('district', '/admin', district.slug);
+    window.location.href = adminUrl;
+  };
+
+  const SortIndicator = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return null;
+    return sortDirection === 'asc' ? (
+      <ChevronUp className="h-3.5 w-3.5 inline ml-1" />
+    ) : (
+      <ChevronDown className="h-3.5 w-3.5 inline ml-1" />
+    );
+  };
 
   if (isLoading) {
     return (
@@ -150,14 +155,13 @@ export function DistrictsPage() {
     <div className="px-6 lg:px-10 py-8 max-w-[1400px] mx-auto">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <div>
+        <div className="flex items-center gap-3">
           <h1 className="font-['Playfair_Display',_Georgia,_serif] text-[28px] font-medium text-[#1a1a1a] tracking-tight">
             Districts
           </h1>
-          <p className="text-sm text-[#8a8a8a] mt-1">
-            {districts.length} district{districts.length !== 1 ? 's' : ''}{' '}
-            registered
-          </p>
+          <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[#f5f3ef] text-[#4a4a4a] border border-[#e8e6e1]">
+            {districts.length}
+          </span>
         </div>
         <Link
           to="/districts/new"
@@ -168,40 +172,286 @@ export function DistrictsPage() {
         </Link>
       </div>
 
-      {/* Search */}
-      <div className="mb-6">
-        <div className="relative max-w-md">
+      {/* Toolbar: Search + Status Filter */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-[#8a8a8a]" />
           <input
             type="text"
             placeholder="Search by name or slug..."
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+              setCurrentPage(1);
+            }}
             className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-[#e8e6e1] bg-white text-sm focus:outline-none focus:border-[#c9a227] focus:ring-1 focus:ring-[#c9a227] placeholder:text-[#8a8a8a]"
           />
         </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value as StatusFilter);
+            setCurrentPage(1);
+          }}
+          className="px-3 py-2.5 rounded-lg border border-[#e8e6e1] bg-white text-sm text-[#4a4a4a] focus:outline-none focus:border-[#c9a227] focus:ring-1 focus:ring-[#c9a227]"
+        >
+          <option value="all">All Status</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
       </div>
 
-      {/* Grid */}
-      {filteredDistricts.length === 0 ? (
+      {/* Table */}
+      {filtered.length === 0 ? (
         <div className="bg-white border border-[#e8e6e1] rounded-xl p-12 text-center">
           <div className="w-14 h-14 rounded-xl bg-[#f5f3ef] flex items-center justify-center mx-auto mb-4">
             <Building2 className="h-7 w-7 text-[#8a8a8a]" />
           </div>
           <p className="text-sm font-medium text-[#4a4a4a] mb-1">
-            {searchTerm ? 'No districts match your search' : 'No districts yet'}
+            {searchTerm || statusFilter !== 'all'
+              ? 'No districts match your filters'
+              : 'No districts yet'}
           </p>
           <p className="text-xs text-[#8a8a8a]">
-            {searchTerm
-              ? 'Try a different search term'
+            {searchTerm || statusFilter !== 'all'
+              ? 'Try adjusting your search or filter'
               : 'Create your first district to get started'}
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-          {filteredDistricts.map((district) => (
-            <DistrictCardItem key={district.id} district={district} />
-          ))}
+        <div className="bg-white border border-[#e8e6e1] rounded-xl overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[#e8e6e1] bg-[#faf9f7]">
+                <th
+                  className="text-left text-xs font-semibold text-[#4a4a4a] uppercase tracking-wider px-4 py-3 cursor-pointer hover:text-[#1a1a1a] select-none"
+                  onClick={() => handleSort('name')}
+                >
+                  District
+                  <SortIndicator field="name" />
+                </th>
+                <th
+                  className="text-left text-xs font-semibold text-[#4a4a4a] uppercase tracking-wider px-4 py-3 cursor-pointer hover:text-[#1a1a1a] select-none"
+                  onClick={() => handleSort('status')}
+                >
+                  Status
+                  <SortIndicator field="status" />
+                </th>
+                <th className="text-left text-xs font-semibold text-[#4a4a4a] uppercase tracking-wider px-4 py-3">
+                  Stats
+                </th>
+                <th
+                  className="text-left text-xs font-semibold text-[#4a4a4a] uppercase tracking-wider px-4 py-3 cursor-pointer hover:text-[#1a1a1a] select-none"
+                  onClick={() => handleSort('created_at')}
+                >
+                  Created
+                  <SortIndicator field="created_at" />
+                </th>
+                <th className="w-12 px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {paginated.map((district) => (
+                <tr
+                  key={district.id}
+                  onClick={() => handleRowClick(district)}
+                  className="border-b border-[#e8e6e1] last:border-b-0 hover:bg-[#f5f3ef] transition-colors cursor-pointer"
+                >
+                  {/* District column */}
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="w-[3px] h-10 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: district.primary_color || '#c9a227' }}
+                      />
+                      {district.logo_url ? (
+                        <img
+                          src={district.logo_url}
+                          alt=""
+                          className="w-8 h-8 rounded-lg object-cover flex-shrink-0"
+                        />
+                      ) : (
+                        <div
+                          className="w-8 h-8 rounded-lg flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                          style={{ backgroundColor: district.primary_color || '#c9a227' }}
+                        >
+                          {district.name.charAt(0)}
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold text-[#1a1a1a] truncate">
+                          {district.name}
+                        </div>
+                        <code className="text-xs text-[#8a8a8a]">{district.slug}</code>
+                      </div>
+                    </div>
+                  </td>
+                  {/* Status column */}
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${
+                        district.is_public
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-gray-100 text-gray-600'
+                      }`}
+                    >
+                      {district.is_public ? 'Active' : 'Inactive'}
+                    </span>
+                  </td>
+                  {/* Stats column */}
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-4 text-xs text-[#4a4a4a]">
+                      <span className="flex items-center gap-1">
+                        <Target className="h-3.5 w-3.5 text-[#8a8a8a]" />
+                        {district.goals_count}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <GraduationCap className="h-3.5 w-3.5 text-[#8a8a8a]" />
+                        {district.schools_count}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Users className="h-3.5 w-3.5 text-[#8a8a8a]" />
+                        {district.users_count}
+                      </span>
+                    </div>
+                  </td>
+                  {/* Created column */}
+                  <td className="px-4 py-3 text-sm text-[#4a4a4a]">
+                    {formatRelativeDate(district.created_at)}
+                  </td>
+                  {/* Actions column */}
+                  <td
+                    className="px-4 py-3 relative"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      aria-label="Actions"
+                      onClick={() =>
+                        setActiveMenu(activeMenu === district.id ? null : district.id)
+                      }
+                      className="w-8 h-8 rounded-lg hover:bg-[#e8e6e1] text-[#8a8a8a] hover:text-[#4a4a4a] flex items-center justify-center transition-colors"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </button>
+                    <DistrictActionsMenu
+                      district={district as unknown as District}
+                      isOpen={activeMenu === district.id}
+                      onClose={() => setActiveMenu(null)}
+                      onEdit={() => {
+                        setEditingDistrict(district);
+                        setActiveMenu(null);
+                      }}
+                      onDelete={() => {
+                        setDeletingDistrict(district);
+                        setActiveMenu(null);
+                      }}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Pagination */}
+          {filtered.length > PAGE_SIZE && (
+            <div className="flex items-center justify-between px-4 py-3 border-t border-[#e8e6e1] bg-[#faf9f7]">
+              <p className="text-xs text-[#8a8a8a]">
+                Showing {rangeStart}&ndash;{rangeEnd} of {filtered.length} districts
+              </p>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="p-1.5 rounded hover:bg-[#e8e6e1] disabled:opacity-40 disabled:cursor-not-allowed text-[#4a4a4a]"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                  <button
+                    key={page}
+                    onClick={() => setCurrentPage(page)}
+                    className={`min-w-[28px] h-7 rounded text-xs font-medium transition-colors ${
+                      currentPage === page
+                        ? 'bg-[#b85c38] text-white'
+                        : 'hover:bg-[#e8e6e1] text-[#4a4a4a]'
+                    }`}
+                  >
+                    {page}
+                  </button>
+                ))}
+                <button
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="p-1.5 rounded hover:bg-[#e8e6e1] disabled:opacity-40 disabled:cursor-not-allowed text-[#4a4a4a]"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editingDistrict && (
+        <DistrictFormModal
+          district={editingDistrict as unknown as District}
+          onClose={() => setEditingDistrict(null)}
+          onSubmit={handleEditSubmit}
+          isLoading={updateDistrict.isPending}
+        />
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deletingDistrict && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white border border-[#e8e6e1] rounded-lg p-6 max-w-md w-full mx-4">
+            <h3 className="text-lg font-semibold text-[#1a1a1a] mb-3">Delete District</h3>
+            <p className="text-sm text-[#4a4a4a] mb-4">
+              This will permanently delete{' '}
+              <strong>{deletingDistrict.name}</strong> and all associated data
+              including goals, metrics, and team members.
+            </p>
+            <div className="mb-4">
+              <label className="block text-sm text-[#4a4a4a] mb-1">
+                Type <strong>{deletingDistrict.slug}</strong> to confirm
+              </label>
+              <input
+                type="text"
+                value={deleteConfirmSlug}
+                onChange={(e) => setDeleteConfirmSlug(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-[#e8e6e1] text-sm focus:outline-none focus:border-red-400 focus:ring-1 focus:ring-red-400"
+                placeholder={deletingDistrict.slug}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setDeletingDistrict(null);
+                  setDeleteConfirmSlug('');
+                }}
+                className="px-4 py-2 rounded-lg border border-[#e8e6e1] text-sm text-[#4a4a4a] hover:bg-[#f5f3ef] transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={
+                  deleteConfirmSlug !== deletingDistrict.slug || deleteDistrict.isPending
+                }
+                className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {deleteDistrict.isPending ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Deleting...
+                  </span>
+                ) : (
+                  'Delete District'
+                )}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Redesigned Districts page** from card grid to sortable/filterable data table with full CRUD operations (edit via modal, delete with slug-typing confirmation)
- **Updated DistrictFormModal** with admin_email, secondary_color, and is_public toggle fields
- **Configured wildcard DNS** (`*.stratadash.org` CNAME in Cloudflare + per-district domains in Vercel) so new district subdomains resolve automatically
- **Added 3 E2E test suites** for district CRUD, routing parity, and cross-district auth

### Districts Table Features
- Column sorting (name, status, created date)
- Search by name/slug + Active/Inactive status filter
- Client-side pagination (25 rows/page)
- Clickable rows navigate to district admin
- Actions menu wired to existing DistrictActionsMenu component
- Delete confirmation requires typing district slug (safety for destructive action)
- Matches editorial design system (warm tones, Playfair Display, #b85c38 accent)

### Infrastructure (manual, already done)
- Cloudflare: wildcard `*` CNAME → `cname.vercel-dns.com`
- Cloudflare: updated root A record to `216.150.1.1`, www CNAME to new Vercel target
- Vercel: added `eastside.stratadash.org` domain
- New customer onboarding = single Vercel domain add (DNS handled by wildcard)

## Test plan

- [ ] Visit `/districts?subdomain=admin` — table renders with all districts
- [ ] Search filters in real-time by name/slug
- [ ] Status dropdown filters Active/Inactive
- [ ] Column headers toggle sort direction
- [ ] Actions menu → Edit opens pre-filled modal, save updates district
- [ ] Actions menu → Delete opens confirmation, typing slug enables delete button
- [ ] `eastside.stratadash.org` resolves and shows Eastside public page
- [ ] `eastside.stratadash.org/admin` shows admin after login
- [ ] Unit tests pass (731/731)
- [ ] Lint + type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Districts form now supports secondary color selection, admin email, and status (Active/Inactive) toggle
  * Districts admin page redesigned with sortable table columns, status filtering, search functionality, and row-level action menus for editing and deletion

* **Tests**
  * Added comprehensive end-to-end tests for district management operations, routing, and authentication workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->