### PR TITLE
feat: add Resend email integration + password reset flow

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,6 +24,9 @@ PLAYWRIGHT_BASE_URL=http://localhost:5174
 # Deploy the worker from cloudflare-workers/r2-upload-worker/
 VITE_R2_UPLOAD_WORKER_URL=https://r2-upload-worker.pernell.workers.dev
 
+# Resend (transactional email)
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # Optional: Enable debug logging
 # DEBUG=true
 

--- a/api/lib/__tests__/email-templates.test.ts
+++ b/api/lib/__tests__/email-templates.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { invitationEmailHtml, passwordResetEmailHtml } from '../email-templates';
+
+describe('email-templates', () => {
+  describe('invitationEmailHtml', () => {
+    it('returns valid HTML containing the organization name', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('Westside ISD');
+    });
+
+    it('contains the inviter name', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('Jane Admin');
+    });
+
+    it('contains the role', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('editor');
+    });
+
+    it('contains the accept URL as an href', () => {
+      const url = 'https://stratadash.org/invite/abc123';
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', url);
+      expect(html).toContain(`href="${url}"`);
+    });
+
+    it('contains the CTA button text', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('Accept Invitation');
+    });
+
+    it('contains a disclaimer footer', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('ignore this email');
+    });
+
+    it('contains StrataDash branding', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('StrataDash');
+    });
+
+    it('is a complete HTML document', () => {
+      const html = invitationEmailHtml('Westside ISD', 'Jane Admin', 'editor', 'https://stratadash.org/invite/abc123');
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('</html>');
+    });
+  });
+
+  describe('passwordResetEmailHtml', () => {
+    it('contains the reset URL as an href', () => {
+      const url = 'https://stratadash.org/reset-password?token=xyz';
+      const html = passwordResetEmailHtml(url);
+      expect(html).toContain(`href="${url}"`);
+    });
+
+    it('contains the CTA button text', () => {
+      const html = passwordResetEmailHtml('https://stratadash.org/reset-password?token=xyz');
+      expect(html).toContain('Reset Password');
+    });
+
+    it('mentions the expiry time', () => {
+      const html = passwordResetEmailHtml('https://stratadash.org/reset-password?token=xyz');
+      expect(html).toContain('1 hour');
+    });
+
+    it('contains a safety disclaimer', () => {
+      const html = passwordResetEmailHtml('https://stratadash.org/reset-password?token=xyz');
+      expect(html).toContain('safely ignore');
+    });
+
+    it('contains StrataDash branding', () => {
+      const html = passwordResetEmailHtml('https://stratadash.org/reset-password?token=xyz');
+      expect(html).toContain('StrataDash');
+    });
+
+    it('is a complete HTML document', () => {
+      const html = passwordResetEmailHtml('https://stratadash.org/reset-password?token=xyz');
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('</html>');
+    });
+  });
+});

--- a/api/lib/__tests__/url.test.ts
+++ b/api/lib/__tests__/url.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getAppBaseUrl } from '../url';
+
+describe('getAppBaseUrl', () => {
+  beforeEach(() => {
+    // Clear env vars before each test
+    delete process.env.BETTER_AUTH_URL;
+    delete process.env.VERCEL_URL;
+  });
+
+  it('returns BETTER_AUTH_URL when set', () => {
+    process.env.BETTER_AUTH_URL = 'https://www.stratadash.org';
+    expect(getAppBaseUrl()).toBe('https://www.stratadash.org');
+  });
+
+  it('returns https://VERCEL_URL when BETTER_AUTH_URL is not set', () => {
+    process.env.VERCEL_URL = 'my-app-abc123.vercel.app';
+    expect(getAppBaseUrl()).toBe('https://my-app-abc123.vercel.app');
+  });
+
+  it('prefers BETTER_AUTH_URL over VERCEL_URL', () => {
+    process.env.BETTER_AUTH_URL = 'https://www.stratadash.org';
+    process.env.VERCEL_URL = 'my-app-abc123.vercel.app';
+    expect(getAppBaseUrl()).toBe('https://www.stratadash.org');
+  });
+
+  it('returns localhost:5174 when no env vars are set', () => {
+    expect(getAppBaseUrl()).toBe('http://localhost:5174');
+  });
+});

--- a/api/lib/auth.ts
+++ b/api/lib/auth.ts
@@ -2,6 +2,8 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "./db.js";
 import * as schema from "./schema/index.js";
+import { sendEmail } from "./email.js";
+import { passwordResetEmailHtml } from "./email-templates.js";
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined),
@@ -13,6 +15,13 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,
+    sendResetPassword: async ({ user, url }) => {
+      await sendEmail({
+        to: user.email,
+        subject: "Reset your StrataDash password",
+        html: passwordResetEmailHtml(url),
+      });
+    },
   },
   session: {
     cookieCache: {

--- a/api/lib/email-templates.ts
+++ b/api/lib/email-templates.ts
@@ -1,0 +1,84 @@
+const BRAND_COLOR = "#4f46e5";
+const BG_COLOR = "#f4f5f7";
+
+function layout(content: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>StrataDash</title>
+</head>
+<body style="margin:0;padding:0;background-color:${BG_COLOR};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BG_COLOR};">
+    <tr>
+      <td align="center" style="padding:40px 20px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color:${BRAND_COLOR};padding:24px 32px;">
+              <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:700;letter-spacing:-0.3px;">StrataDash</h1>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              ${content}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+function ctaButton(url: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:28px 0;">
+  <tr>
+    <td style="border-radius:6px;background-color:${BRAND_COLOR};">
+      <a href="${url}" target="_blank" style="display:inline-block;padding:14px 32px;color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;border-radius:6px;">${label}</a>
+    </td>
+  </tr>
+</table>`;
+}
+
+function footer(text: string): string {
+  return `<p style="margin:24px 0 0;font-size:13px;color:#6b7280;line-height:1.5;">${text}</p>`;
+}
+
+export function invitationEmailHtml(
+  orgName: string,
+  inviterName: string,
+  role: string,
+  acceptUrl: string,
+): string {
+  const content = `
+    <h2 style="margin:0 0 16px;font-size:20px;color:#111827;font-weight:600;">You've been invited!</h2>
+    <p style="margin:0 0 8px;font-size:16px;color:#374151;line-height:1.6;">
+      <strong>${inviterName}</strong> has invited you to join <strong>${orgName}</strong> on StrataDash as a <strong>${role}</strong>.
+    </p>
+    <p style="margin:0;font-size:16px;color:#374151;line-height:1.6;">
+      Click the button below to accept the invitation and get started.
+    </p>
+    ${ctaButton(acceptUrl, "Accept Invitation")}
+    ${footer("If you didn't expect this invitation, you can ignore this email.")}
+  `;
+  return layout(content);
+}
+
+export function passwordResetEmailHtml(resetUrl: string): string {
+  const content = `
+    <h2 style="margin:0 0 16px;font-size:20px;color:#111827;font-weight:600;">Reset your password</h2>
+    <p style="margin:0 0 8px;font-size:16px;color:#374151;line-height:1.6;">
+      We received a request to reset your StrataDash password. Click the button below to choose a new password.
+    </p>
+    <p style="margin:0;font-size:14px;color:#6b7280;line-height:1.5;">
+      This link will expire in 1 hour.
+    </p>
+    ${ctaButton(resetUrl, "Reset Password")}
+    ${footer("If you didn't request this, you can safely ignore this email. Your password will not be changed.")}
+  `;
+  return layout(content);
+}

--- a/api/lib/email.ts
+++ b/api/lib/email.ts
@@ -1,0 +1,24 @@
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM_ADDRESS = "StrataDash <noreply@stratadash.org>";
+
+export async function sendEmail(options: {
+  to: string;
+  subject: string;
+  html: string;
+}) {
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("[email] RESEND_API_KEY not set, skipping email send");
+    return null;
+  }
+  const { data, error } = await resend.emails.send({
+    from: FROM_ADDRESS,
+    ...options,
+  });
+  if (error) {
+    console.error("[email] Failed to send:", error);
+    return null;
+  }
+  return data;
+}

--- a/api/lib/url.ts
+++ b/api/lib/url.ts
@@ -1,0 +1,5 @@
+export function getAppBaseUrl(): string {
+  if (process.env.BETTER_AUTH_URL) return process.env.BETTER_AUTH_URL;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "http://localhost:5174";
+}

--- a/api/organizations/[slug]/invitations/[id]/resend.ts
+++ b/api/organizations/[slug]/invitations/[id]/resend.ts
@@ -3,6 +3,9 @@ import { db } from "../../../../lib/db.js";
 import { organizationInvitations } from "../../../../lib/schema/index.js";
 import { requireOrgMember } from "../../../../lib/middleware/auth.js";
 import { jsonOk, jsonError } from "../../../../lib/response.js";
+import { sendEmail } from "../../../../lib/email.js";
+import { invitationEmailHtml } from "../../../../lib/email-templates.js";
+import { getAppBaseUrl } from "../../../../lib/url.js";
 
 function getSlugFromUrl(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");
@@ -55,6 +58,19 @@ export async function POST(req: Request) {
       .set({ token: newToken, expiresAt: newExpiry })
       .where(eq(organizationInvitations.id, id))
       .returning();
+
+    // Fire-and-forget resend invitation email
+    const acceptUrl = `${getAppBaseUrl()}/invite/${updated.token}`;
+    void sendEmail({
+      to: updated.email,
+      subject: `You've been invited to ${organization.name} on StrataDash`,
+      html: invitationEmailHtml(
+        organization.name,
+        "An administrator",
+        updated.role,
+        acceptUrl,
+      ),
+    });
 
     return jsonOk({
       id: updated.id,

--- a/api/organizations/[slug]/invitations/index.ts
+++ b/api/organizations/[slug]/invitations/index.ts
@@ -8,6 +8,9 @@ import {
 } from "../../../lib/schema/index.js";
 import { requireOrgMember } from "../../../lib/middleware/auth.js";
 import { jsonOk, jsonError } from "../../../lib/response.js";
+import { sendEmail } from "../../../lib/email.js";
+import { invitationEmailHtml } from "../../../lib/email-templates.js";
+import { getAppBaseUrl } from "../../../lib/url.js";
 
 function getSlugFromUrl(req: Request): string {
   const segments = new URL(req.url).pathname.split("/");
@@ -156,6 +159,19 @@ export async function POST(req: Request) {
         expiresAt,
       })
       .returning();
+
+    // Fire-and-forget invitation email
+    const acceptUrl = `${getAppBaseUrl()}/invite/${token}`;
+    void sendEmail({
+      to: normalizedEmail,
+      subject: `You've been invited to ${organization.name} on StrataDash`,
+      html: invitationEmailHtml(
+        organization.name,
+        currentUser.name ?? "An administrator",
+        role,
+        acceptUrl,
+      ),
+    });
 
     return jsonOk(
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-hook-form": "^7.63.0",
         "react-router-dom": "^7.9.1",
         "recharts": "^3.2.1",
+        "resend": "^6.9.2",
         "tailwind-merge": "^3.3.1",
         "xlsx": "^0.18.5",
         "zod": "^4.1.11"
@@ -2798,6 +2799,12 @@
         "win32"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -5135,6 +5142,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6695,6 +6708,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -7230,6 +7249,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
+    "node_modules/resend": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.2.tgz",
+      "integrity": "sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -7562,6 +7602,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "devOptional": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -7754,6 +7804,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -8616,6 +8676,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-hook-form": "^7.63.0",
     "react-router-dom": "^7.9.1",
     "recharts": "^3.2.1",
+    "resend": "^6.9.2",
     "tailwind-merge": "^3.3.1",
     "xlsx": "^0.18.5",
     "zod": "^4.1.11"

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { authClient } from '../lib/auth-client';
+import { AlertCircle, Loader2, ArrowLeft, CheckCircle } from 'lucide-react';
+
+export function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+
+    if (!email) {
+      setError('Please enter your email address.');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      await authClient.requestPasswordReset({
+        email,
+        redirectTo: '/reset-password',
+      });
+      setIsSubmitted(true);
+    } catch (err) {
+      // Network errors only — API-level "user not found" is suppressed
+      // to prevent email enumeration
+      if (err instanceof Error && err.message.includes('fetch')) {
+        setError('Unable to connect. Please check your internet connection and try again.');
+      } else {
+        // Still show success to prevent email enumeration
+        setIsSubmitted(true);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen w-full bg-white text-slate-900 antialiased">
+      <style>{`
+        .fade-in { animation: fadeIn 0.6s ease-out forwards; opacity: 0; }
+        @keyframes fadeIn { to { opacity: 1; } }
+      `}</style>
+
+      {/* Left Side: Forgot Password Form */}
+      <div className="flex flex-1 flex-col px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24 bg-white z-10 pt-12 pb-12 relative justify-center">
+        <div className="mx-auto w-full max-w-sm lg:w-96 fade-in">
+          {/* Logo */}
+          <div className="flex items-center gap-3 mb-10">
+            <div className="h-10 w-10 overflow-hidden rounded-lg shadow-sm">
+              <img
+                src="/assets/stratadash-logo.png"
+                alt="StrataDash"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <span className="text-xl font-semibold tracking-tight text-slate-900">StrataDash</span>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+              Forgot your password?
+            </h2>
+            <p className="mt-2 text-sm text-slate-500">
+              Enter your email and we'll send you a reset link.
+            </p>
+          </div>
+
+          <div className="mt-10">
+            {/* Error Alert */}
+            {error && (
+              <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-3">
+                <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-sm text-red-600 font-medium">Error</p>
+                  <p className="text-sm text-red-500 mt-1">{error}</p>
+                </div>
+              </div>
+            )}
+
+            {/* Success Message */}
+            {isSubmitted && (
+              <div className="mb-6 bg-green-50 border border-green-200 rounded-lg p-4 flex items-start gap-3">
+                <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-sm text-green-700 font-medium">Check your email</p>
+                  <p className="text-sm text-green-600 mt-1">
+                    If an account exists with that email, we've sent a password reset link.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Email Field */}
+              <div>
+                <label htmlFor="email" className="block text-sm font-medium leading-6 text-slate-700">
+                  Email address
+                </label>
+                <div className="mt-2">
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    placeholder="Enter your email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={isLoading || isSubmitted}
+                    className="block w-full rounded-lg border-0 py-2.5 px-3 text-slate-900 shadow-sm ring-1 ring-inset ring-slate-200 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 transition-shadow disabled:opacity-50"
+                  />
+                </div>
+              </div>
+
+              {/* Submit Button */}
+              <div>
+                <button
+                  type="submit"
+                  disabled={isLoading || isSubmitted}
+                  className="flex w-full justify-center items-center gap-2 rounded-lg bg-slate-900 px-3 py-2.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-all hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Sending...
+                    </>
+                  ) : (
+                    'Send reset link'
+                  )}
+                </button>
+              </div>
+            </form>
+
+            {/* Back to Login Link */}
+            <div className="mt-8 text-center">
+              <Link
+                to="/login"
+                className="inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-500 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Back to login
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Mobile Footer */}
+        <div className="mt-16 lg:hidden text-center text-xs text-slate-400">
+          &copy; {new Date().getFullYear()} StrataDash.
+        </div>
+      </div>
+
+      {/* Right Side: Branding */}
+      <div className="relative hidden w-0 flex-1 lg:block bg-slate-950 overflow-hidden">
+        {/* Grid Background with Vignette Mask */}
+        <div className="absolute inset-0 h-full w-full bg-[linear-gradient(to_right,#ffffff0a_1px,transparent_1px),linear-gradient(to_bottom,#ffffff0a_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_50%,#000_70%,transparent_100%)]" />
+
+        {/* Subtle Purple/Indigo Glow */}
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-indigo-600/20 rounded-full blur-[100px] pointer-events-none" />
+
+        <div
+          className="flex flex-col fade-in text-center h-full p-12 relative items-center justify-center z-10"
+          style={{ animationDelay: '0.1s' }}
+        >
+          <div className="flex flex-col items-center gap-8 max-w-lg">
+            {/* Logo Container with Glow */}
+            <div className="relative group">
+              <div className="absolute -inset-1 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-2xl blur opacity-25 group-hover:opacity-40 transition duration-1000 group-hover:duration-200" />
+              <div className="relative h-28 w-28 overflow-hidden rounded-2xl bg-indigo-950 ring-1 ring-white/10 shadow-2xl">
+                <img
+                  src="/assets/stratadash-logo.png"
+                  alt="StrataDash Logo"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="text-5xl font-semibold tracking-tight text-white">StrataDash</h1>
+              <p className="text-lg text-slate-400 font-medium leading-relaxed">
+                The intelligent strategic planning platform designed for K-12 Districts.
+              </p>
+            </div>
+
+            {/* Decorative Dots */}
+            <div className="flex gap-2 mt-4">
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/50" />
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/20" />
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom Legal Text */}
+        <div className="absolute bottom-10 left-0 right-0 text-center">
+          <p className="text-xs text-slate-500 font-medium tracking-wide uppercase opacity-60">
+            Empowering Education Leadership
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,402 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { authClient } from '../lib/auth-client';
+import { AlertCircle, Loader2, CheckCircle, KeyRound } from 'lucide-react';
+
+export function ResetPassword() {
+  const token = new URLSearchParams(window.location.search).get('token');
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{ password?: string; confirm?: string }>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const validate = (): boolean => {
+    const errors: { password?: string; confirm?: string } = {};
+
+    if (newPassword.length < 8) {
+      errors.password = 'Password must be at least 8 characters.';
+    }
+
+    if (newPassword !== confirmPassword) {
+      errors.confirm = 'Passwords do not match.';
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setFieldErrors({});
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const { error: resetError } = await authClient.resetPassword({
+        newPassword,
+        token: token!,
+      });
+
+      if (resetError) {
+        setError('This reset link has expired or is invalid. Please request a new one.');
+      } else {
+        setIsSuccess(true);
+      }
+    } catch (err) {
+      console.error('[ResetPassword] Error:', err);
+      setError('This reset link has expired or is invalid. Please request a new one.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // No token present — show error state
+  if (!token) {
+    return (
+      <div className="flex min-h-screen w-full bg-white text-slate-900 antialiased">
+        <style>{`
+          .fade-in { animation: fadeIn 0.6s ease-out forwards; opacity: 0; }
+          @keyframes fadeIn { to { opacity: 1; } }
+        `}</style>
+
+        {/* Left Side */}
+        <div className="flex flex-1 flex-col px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24 bg-white z-10 pt-12 pb-12 relative justify-center">
+          <div className="mx-auto w-full max-w-sm lg:w-96 fade-in">
+            {/* Logo */}
+            <div className="flex items-center gap-3 mb-10">
+              <div className="h-10 w-10 overflow-hidden rounded-lg shadow-sm">
+                <img
+                  src="/assets/stratadash-logo.png"
+                  alt="StrataDash"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <span className="text-xl font-semibold tracking-tight text-slate-900">StrataDash</span>
+            </div>
+
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+                Invalid or missing reset link
+              </h2>
+              <p className="mt-2 text-sm text-slate-500">
+                This password reset link is invalid or has expired.
+              </p>
+            </div>
+
+            <div className="mt-10">
+              <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-3">
+                <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-sm text-red-600 font-medium">Invalid Link</p>
+                  <p className="text-sm text-red-500 mt-1">
+                    The reset token is missing from the URL. Please request a new password reset link.
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <Link
+                  to="/forgot-password"
+                  className="flex w-full justify-center items-center gap-2 rounded-lg bg-slate-900 px-3 py-2.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-all hover:shadow-md"
+                >
+                  Request a new reset link
+                </Link>
+                <div className="text-center">
+                  <Link
+                    to="/login"
+                    className="text-sm font-medium text-indigo-600 hover:text-indigo-500 transition-colors"
+                  >
+                    Back to login
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Mobile Footer */}
+          <div className="mt-16 lg:hidden text-center text-xs text-slate-400">
+            &copy; {new Date().getFullYear()} StrataDash.
+          </div>
+        </div>
+
+        {/* Right Side: Branding */}
+        <div className="relative hidden w-0 flex-1 lg:block bg-slate-950 overflow-hidden">
+          <div className="absolute inset-0 h-full w-full bg-[linear-gradient(to_right,#ffffff0a_1px,transparent_1px),linear-gradient(to_bottom,#ffffff0a_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_50%,#000_70%,transparent_100%)]" />
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-indigo-600/20 rounded-full blur-[100px] pointer-events-none" />
+          <div
+            className="flex flex-col fade-in text-center h-full p-12 relative items-center justify-center z-10"
+            style={{ animationDelay: '0.1s' }}
+          >
+            <div className="flex flex-col items-center gap-8 max-w-lg">
+              <div className="relative group">
+                <div className="absolute -inset-1 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-2xl blur opacity-25 group-hover:opacity-40 transition duration-1000 group-hover:duration-200" />
+                <div className="relative h-28 w-28 overflow-hidden rounded-2xl bg-indigo-950 ring-1 ring-white/10 shadow-2xl">
+                  <img
+                    src="/assets/stratadash-logo.png"
+                    alt="StrataDash Logo"
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              </div>
+              <div className="space-y-4">
+                <h1 className="text-5xl font-semibold tracking-tight text-white">StrataDash</h1>
+                <p className="text-lg text-slate-400 font-medium leading-relaxed">
+                  The intelligent strategic planning platform designed for K-12 Districts.
+                </p>
+              </div>
+              <div className="flex gap-2 mt-4">
+                <div className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
+                <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/50" />
+                <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/20" />
+              </div>
+            </div>
+          </div>
+          <div className="absolute bottom-10 left-0 right-0 text-center">
+            <p className="text-xs text-slate-500 font-medium tracking-wide uppercase opacity-60">
+              Empowering Education Leadership
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen w-full bg-white text-slate-900 antialiased">
+      <style>{`
+        .fade-in { animation: fadeIn 0.6s ease-out forwards; opacity: 0; }
+        @keyframes fadeIn { to { opacity: 1; } }
+      `}</style>
+
+      {/* Left Side: Reset Password Form */}
+      <div className="flex flex-1 flex-col px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24 bg-white z-10 pt-12 pb-12 relative justify-center">
+        <div className="mx-auto w-full max-w-sm lg:w-96 fade-in">
+          {/* Logo */}
+          <div className="flex items-center gap-3 mb-10">
+            <div className="h-10 w-10 overflow-hidden rounded-lg shadow-sm">
+              <img
+                src="/assets/stratadash-logo.png"
+                alt="StrataDash"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <span className="text-xl font-semibold tracking-tight text-slate-900">StrataDash</span>
+          </div>
+
+          {isSuccess ? (
+            /* Success State */
+            <>
+              <div>
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+                  Password reset complete
+                </h2>
+                <p className="mt-2 text-sm text-slate-500">
+                  You can now log in with your new password.
+                </p>
+              </div>
+
+              <div className="mt-10">
+                <div className="mb-6 bg-green-50 border border-green-200 rounded-lg p-4 flex items-start gap-3">
+                  <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="text-sm text-green-700 font-medium">Success</p>
+                    <p className="text-sm text-green-600 mt-1">
+                      Your password has been reset successfully.
+                    </p>
+                  </div>
+                </div>
+
+                <Link
+                  to="/login"
+                  className="flex w-full justify-center items-center gap-2 rounded-lg bg-slate-900 px-3 py-2.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-all hover:shadow-md"
+                >
+                  Back to login
+                </Link>
+              </div>
+            </>
+          ) : (
+            /* Form State */
+            <>
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <KeyRound className="w-6 h-6 text-slate-400" />
+                  <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+                    Set new password
+                  </h2>
+                </div>
+                <p className="mt-2 text-sm text-slate-500">
+                  Enter your new password below.
+                </p>
+              </div>
+
+              <div className="mt-10">
+                {/* Error Alert */}
+                {error && (
+                  <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-3">
+                    <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1">
+                      <p className="text-sm text-red-600 font-medium">Reset Failed</p>
+                      <p className="text-sm text-red-500 mt-1">{error}</p>
+                      <Link
+                        to="/forgot-password"
+                        className="text-sm font-medium text-indigo-600 hover:text-indigo-500 transition-colors mt-2 inline-block"
+                      >
+                        Request a new reset link
+                      </Link>
+                    </div>
+                  </div>
+                )}
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                  {/* New Password Field */}
+                  <div>
+                    <label htmlFor="new-password" className="block text-sm font-medium leading-6 text-slate-700">
+                      New password
+                    </label>
+                    <div className="mt-2">
+                      <input
+                        id="new-password"
+                        name="new-password"
+                        type="password"
+                        autoComplete="new-password"
+                        required
+                        placeholder="Min. 8 characters"
+                        value={newPassword}
+                        onChange={(e) => {
+                          setNewPassword(e.target.value);
+                          if (fieldErrors.password) setFieldErrors((prev) => ({ ...prev, password: undefined }));
+                        }}
+                        disabled={isLoading}
+                        className="block w-full rounded-lg border-0 py-2.5 px-3 text-slate-900 shadow-sm ring-1 ring-inset ring-slate-200 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 transition-shadow disabled:opacity-50"
+                      />
+                    </div>
+                    {fieldErrors.password && (
+                      <p className="mt-1.5 text-sm text-red-600">{fieldErrors.password}</p>
+                    )}
+                  </div>
+
+                  {/* Confirm Password Field */}
+                  <div>
+                    <label htmlFor="confirm-password" className="block text-sm font-medium leading-6 text-slate-700">
+                      Confirm password
+                    </label>
+                    <div className="mt-2">
+                      <input
+                        id="confirm-password"
+                        name="confirm-password"
+                        type="password"
+                        autoComplete="new-password"
+                        required
+                        placeholder="Re-enter your password"
+                        value={confirmPassword}
+                        onChange={(e) => {
+                          setConfirmPassword(e.target.value);
+                          if (fieldErrors.confirm) setFieldErrors((prev) => ({ ...prev, confirm: undefined }));
+                        }}
+                        disabled={isLoading}
+                        className="block w-full rounded-lg border-0 py-2.5 px-3 text-slate-900 shadow-sm ring-1 ring-inset ring-slate-200 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 transition-shadow disabled:opacity-50"
+                      />
+                    </div>
+                    {fieldErrors.confirm && (
+                      <p className="mt-1.5 text-sm text-red-600">{fieldErrors.confirm}</p>
+                    )}
+                  </div>
+
+                  {/* Submit Button */}
+                  <div>
+                    <button
+                      type="submit"
+                      disabled={isLoading}
+                      className="flex w-full justify-center items-center gap-2 rounded-lg bg-slate-900 px-3 py-2.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-all hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {isLoading ? (
+                        <>
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Resetting...
+                        </>
+                      ) : (
+                        'Reset password'
+                      )}
+                    </button>
+                  </div>
+                </form>
+
+                {/* Back to Login Link */}
+                <div className="mt-8 text-center">
+                  <Link
+                    to="/login"
+                    className="text-sm font-medium text-indigo-600 hover:text-indigo-500 transition-colors"
+                  >
+                    Back to login
+                  </Link>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Mobile Footer */}
+        <div className="mt-16 lg:hidden text-center text-xs text-slate-400">
+          &copy; {new Date().getFullYear()} StrataDash.
+        </div>
+      </div>
+
+      {/* Right Side: Branding */}
+      <div className="relative hidden w-0 flex-1 lg:block bg-slate-950 overflow-hidden">
+        {/* Grid Background with Vignette Mask */}
+        <div className="absolute inset-0 h-full w-full bg-[linear-gradient(to_right,#ffffff0a_1px,transparent_1px),linear-gradient(to_bottom,#ffffff0a_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_50%,#000_70%,transparent_100%)]" />
+
+        {/* Subtle Purple/Indigo Glow */}
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-indigo-600/20 rounded-full blur-[100px] pointer-events-none" />
+
+        <div
+          className="flex flex-col fade-in text-center h-full p-12 relative items-center justify-center z-10"
+          style={{ animationDelay: '0.1s' }}
+        >
+          <div className="flex flex-col items-center gap-8 max-w-lg">
+            {/* Logo Container with Glow */}
+            <div className="relative group">
+              <div className="absolute -inset-1 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-2xl blur opacity-25 group-hover:opacity-40 transition duration-1000 group-hover:duration-200" />
+              <div className="relative h-28 w-28 overflow-hidden rounded-2xl bg-indigo-950 ring-1 ring-white/10 shadow-2xl">
+                <img
+                  src="/assets/stratadash-logo.png"
+                  alt="StrataDash Logo"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="text-5xl font-semibold tracking-tight text-white">StrataDash</h1>
+              <p className="text-lg text-slate-400 font-medium leading-relaxed">
+                The intelligent strategic planning platform designed for K-12 Districts.
+              </p>
+            </div>
+
+            {/* Decorative Dots */}
+            <div className="flex gap-2 mt-4">
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/50" />
+              <div className="h-1.5 w-1.5 rounded-full bg-indigo-500/20" />
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom Legal Text */}
+        <div className="absolute bottom-10 left-0 right-0 text-center">
+          <p className="text-xs text-slate-500 font-medium tracking-wide uppercase opacity-60">
+            Empowering Education Leadership
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/__tests__/ForgotPassword.test.tsx
+++ b/src/pages/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test/setup';
+import userEvent from '@testing-library/user-event';
+import { ForgotPassword } from '../ForgotPassword';
+
+// Mock the auth client
+const mockRequestPasswordReset = vi.fn();
+vi.mock('../../lib/auth-client', () => ({
+  authClient: {
+    requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+  },
+}));
+
+describe('ForgotPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequestPasswordReset.mockResolvedValue({});
+  });
+
+  it('renders the page title and description', () => {
+    render(<ForgotPassword />);
+    expect(screen.getByText('Forgot your password?')).toBeInTheDocument();
+    expect(screen.getByText("Enter your email and we'll send you a reset link.")).toBeInTheDocument();
+  });
+
+  it('renders email input and submit button', () => {
+    render(<ForgotPassword />);
+    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send reset link/i })).toBeInTheDocument();
+  });
+
+  it('has a link back to login', () => {
+    render(<ForgotPassword />);
+    const link = screen.getByText(/back to login/i);
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute('href', '/login');
+  });
+
+  it('calls requestPasswordReset with email on submit', async () => {
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    const emailInput = screen.getByLabelText(/email address/i);
+    await user.type(emailInput, 'test@example.com');
+
+    const submitButton = screen.getByRole('button', { name: /send reset link/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        redirectTo: '/reset-password',
+      });
+    });
+  });
+
+  it('shows success message after submission', async () => {
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/if an account exists/i)).toBeInTheDocument();
+    });
+  });
+
+  it('disables form after successful submission', async () => {
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email address/i)).toBeDisabled();
+      expect(screen.getByRole('button', { name: /send reset link/i })).toBeDisabled();
+    });
+  });
+
+  it('shows success message even when API returns non-fetch error (prevents email enumeration)', async () => {
+    mockRequestPasswordReset.mockRejectedValue(new Error('User not found'));
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'nonexistent@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/if an account exists/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows connection error when fetch fails', async () => {
+    mockRequestPasswordReset.mockRejectedValue(new Error('Failed to fetch'));
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unable to connect/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the branding panel with correct responsive classes', () => {
+    render(<ForgotPassword />);
+    const brandingPanel = screen.getByText('StrataDash', { selector: 'h1' }).closest('div.relative.hidden');
+    expect(brandingPanel).toHaveClass('lg:block');
+  });
+
+  it('submit button has full-width class', () => {
+    render(<ForgotPassword />);
+    const button = screen.getByRole('button', { name: /send reset link/i });
+    expect(button).toHaveClass('w-full');
+  });
+});

--- a/src/pages/__tests__/ResetPassword.test.tsx
+++ b/src/pages/__tests__/ResetPassword.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test/setup';
+import userEvent from '@testing-library/user-event';
+import { ResetPassword } from '../ResetPassword';
+
+// Mock the auth client
+const mockResetPassword = vi.fn();
+vi.mock('../../lib/auth-client', () => ({
+  authClient: {
+    resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+  },
+}));
+
+describe('ResetPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResetPassword.mockResolvedValue({ error: null });
+  });
+
+  describe('without token', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, search: '' },
+        writable: true,
+      });
+    });
+
+    it('shows invalid link error when no token in URL', () => {
+      render(<ResetPassword />);
+      expect(screen.getByText('Invalid or missing reset link')).toBeInTheDocument();
+    });
+
+    it('shows a link to request a new reset', () => {
+      render(<ResetPassword />);
+      const link = screen.getByText(/request a new reset link/i);
+      expect(link.closest('a')).toHaveAttribute('href', '/forgot-password');
+    });
+
+    it('shows a link back to login', () => {
+      render(<ResetPassword />);
+      const link = screen.getByText(/back to login/i);
+      expect(link.closest('a')).toHaveAttribute('href', '/login');
+    });
+
+    it('does not render the password form', () => {
+      render(<ResetPassword />);
+      expect(screen.queryByLabelText(/new password/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with token', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, search: '?token=test-reset-token-123' },
+        writable: true,
+      });
+    });
+
+    it('renders password fields when token is present', () => {
+      render(<ResetPassword />);
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    });
+
+    it('renders the heading "Set new password"', () => {
+      render(<ResetPassword />);
+      expect(screen.getByText('Set new password')).toBeInTheDocument();
+    });
+
+    it('renders submit button', () => {
+      render(<ResetPassword />);
+      expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument();
+    });
+
+    it('shows validation error for short password', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'short');
+      await user.type(screen.getByLabelText(/confirm password/i), 'short');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows validation error for mismatched passwords', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'different123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+      });
+    });
+
+    it('does not call resetPassword when validation fails', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'short');
+      await user.type(screen.getByLabelText(/confirm password/i), 'short');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+      });
+      expect(mockResetPassword).not.toHaveBeenCalled();
+    });
+
+    it('calls resetPassword with token and new password on valid submit', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(mockResetPassword).toHaveBeenCalledWith({
+          newPassword: 'newpassword123',
+          token: 'test-reset-token-123',
+        });
+      });
+    });
+
+    it('shows success message after successful reset', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/password has been reset successfully/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows login link after successful reset', async () => {
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        const loginLink = screen.getByText(/back to login/i);
+        expect(loginLink.closest('a')).toHaveAttribute('href', '/login');
+      });
+    });
+
+    it('shows error for expired/invalid token from API', async () => {
+      mockResetPassword.mockResolvedValue({ error: { message: 'Invalid token' } });
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/expired or is invalid/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows error when resetPassword throws an exception', async () => {
+      mockResetPassword.mockRejectedValue(new Error('Network error'));
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/expired or is invalid/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows link to request new reset on error', async () => {
+      mockResetPassword.mockResolvedValue({ error: { message: 'Invalid token' } });
+      const user = userEvent.setup();
+      render(<ResetPassword />);
+
+      await user.type(screen.getByLabelText(/new password/i), 'newpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'newpassword123');
+      await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+      await waitFor(() => {
+        const link = screen.getByText(/request a new reset link/i);
+        expect(link.closest('a')).toHaveAttribute('href', '/forgot-password');
+      });
+    });
+
+    it('submit button has full-width class', () => {
+      render(<ResetPassword />);
+      const button = screen.getByRole('button', { name: /reset password/i });
+      expect(button).toHaveClass('w-full');
+    });
+
+    it('renders branding panel with responsive classes', () => {
+      render(<ResetPassword />);
+      const brandingPanel = screen.getByText('StrataDash', { selector: 'h1' }).closest('div.relative.hidden');
+      expect(brandingPanel).toHaveClass('lg:block');
+    });
+  });
+});

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -2,6 +2,8 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { MarketingLanding } from '../pages/marketing/Landing';
 import { Login } from '../pages/Login';
 import { Signup } from '../pages/Signup';
+import { ForgotPassword } from '../pages/ForgotPassword';
+import { ResetPassword } from '../pages/ResetPassword';
 import { Welcome } from '../pages/Welcome';
 import { AcceptInvitation } from '../pages/AcceptInvitation';
 import { DistrictRedirect } from '../components/DistrictRedirect';
@@ -76,6 +78,8 @@ export function RootRouter() {
       {/* Auth pages */}
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Signup />} />
+      <Route path="/forgot-password" element={<ForgotPassword />} />
+      <Route path="/reset-password" element={<ResetPassword />} />
       <Route
         path="/welcome"
         element={

--- a/src/routers/__tests__/RootRouterRedirects.test.tsx
+++ b/src/routers/__tests__/RootRouterRedirects.test.tsx
@@ -37,6 +37,12 @@ vi.mock('../../pages/Login', () => ({
 vi.mock('../../pages/Signup', () => ({
   Signup: () => <div>Signup</div>,
 }));
+vi.mock('../../pages/ForgotPassword', () => ({
+  ForgotPassword: () => <div>Forgot Password</div>,
+}));
+vi.mock('../../pages/ResetPassword', () => ({
+  ResetPassword: () => <div>Reset Password</div>,
+}));
 vi.mock('../../pages/Welcome', () => ({
   Welcome: () => <div>Welcome</div>,
 }));


### PR DESCRIPTION
## Summary

- Wire up **Resend** for transactional email delivery (invitation + password reset emails)
- Add **Forgot Password** and **Reset Password** pages with Better Auth integration
- Send invitation emails on create and resend (fire-and-forget)
- Configure Better Auth `sendResetPassword` callback
- 46 new unit tests (777 total passing)

## Changes

### Backend
- `api/lib/email.ts` — Resend client + `sendEmail()` helper (gracefully skips when key not set)
- `api/lib/email-templates.ts` — Professional HTML templates with inline CSS for cross-client compatibility
- `api/lib/url.ts` — `getAppBaseUrl()` with env var fallback chain
- `api/lib/auth.ts` — Added `sendResetPassword` to Better Auth config
- `api/organizations/[slug]/invitations/index.ts` — Fire-and-forget invitation email on POST
- `api/organizations/[slug]/invitations/[id]/resend.ts` — Fire-and-forget email on resend

### Frontend
- `src/pages/ForgotPassword.tsx` — Email form with anti-enumeration success message
- `src/pages/ResetPassword.tsx` — Token-based reset with validation (8+ chars, match)
- `src/routers/RootRouter.tsx` — Added `/forgot-password` and `/reset-password` routes

### Tests
- `api/lib/__tests__/email-templates.test.ts` (14 tests)
- `api/lib/__tests__/url.test.ts` (4 tests)
- `src/pages/__tests__/ForgotPassword.test.tsx` (10 tests)
- `src/pages/__tests__/ResetPassword.test.tsx` (18 tests)

## Test plan
- [x] `npm run test:run` — 777 tests pass
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 errors
- [ ] Manual: `/login` → "Forgot password?" → enter email → check Resend dashboard → click link → set new password → login
- [ ] Manual: Admin → Invite team member → check Resend dashboard for invitation email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Password reset functionality: Users can request password resets and set new passwords via email.
  * Email notifications for organization invitations: Invitees receive confirmation emails when added to organizations.
  * Email notifications for password resets: Users receive reset links when requesting account recovery.

* **Tests**
  * Added comprehensive test coverage for password reset workflows and email template generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->