### PR TITLE
feat(admin): WYSIWYG appearance editor + fix dead logo URL

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -145,8 +145,7 @@ async function seed() {
       slug: "westside",
       entityType: "district",
       entityLabel: "District",
-      logoUrl:
-        "https://www.westside66.org/cms/lib/NE50000555/Centricity/Template/GlobalAssets/images//logos/Westside District STAR BOX.png",
+      logoUrl: "",
       primaryColor: "#C03537",
       secondaryColor: "#000000",
       adminEmail: "admin@westside.edu",

--- a/src/components/admin/appearance/AppearanceContext.tsx
+++ b/src/components/admin/appearance/AppearanceContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext } from 'react';
+import type { AppearanceState, AppearanceAction } from '../../../hooks/useAppearanceState';
+
+interface AppearanceContextValue {
+  state: AppearanceState;
+  dispatch: React.Dispatch<AppearanceAction>;
+  districtName: string;
+  districtTagline?: string;
+  districtSlug: string;
+  save: () => Promise<void>;
+  isSaving: boolean;
+}
+
+const AppearanceContext = createContext<AppearanceContextValue | null>(null);
+
+export function AppearanceProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: AppearanceContextValue;
+}) {
+  return (
+    <AppearanceContext.Provider value={value}>
+      {children}
+    </AppearanceContext.Provider>
+  );
+}
+
+export function useAppearance() {
+  const ctx = useContext(AppearanceContext);
+  if (!ctx) {
+    throw new Error('useAppearance must be used within an AppearanceProvider');
+  }
+  return ctx;
+}

--- a/src/components/admin/appearance/AppearanceEditor.tsx
+++ b/src/components/admin/appearance/AppearanceEditor.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { PanelLeft, Eye } from 'lucide-react';
+import { ConfigPanel } from './config-panel/ConfigPanel';
+import { PreviewPanel } from './preview-panel/PreviewPanel';
+
+/**
+ * AppearanceEditor — Full-height split-view: config panel (left) + live preview (right).
+ * On narrow screens, stacks vertically with a tab toggle.
+ */
+export function AppearanceEditor() {
+  const [mobileTab, setMobileTab] = useState<'config' | 'preview'>('config');
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-64px)]">
+      {/* Mobile tab toggle (< lg) */}
+      <div className="flex lg:hidden border-b" style={{ borderColor: 'var(--editorial-border)' }}>
+        <button
+          onClick={() => setMobileTab('config')}
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+            mobileTab === 'config'
+              ? 'border-b-2'
+              : ''
+          }`}
+          style={{
+            color: mobileTab === 'config' ? 'var(--editorial-accent-primary)' : 'var(--editorial-text-muted)',
+            borderBottomColor: mobileTab === 'config' ? 'var(--editorial-accent-primary)' : 'transparent',
+          }}
+        >
+          <PanelLeft className="w-4 h-4" />
+          Settings
+        </button>
+        <button
+          onClick={() => setMobileTab('preview')}
+          className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+            mobileTab === 'preview'
+              ? 'border-b-2'
+              : ''
+          }`}
+          style={{
+            color: mobileTab === 'preview' ? 'var(--editorial-accent-primary)' : 'var(--editorial-text-muted)',
+            borderBottomColor: mobileTab === 'preview' ? 'var(--editorial-accent-primary)' : 'transparent',
+          }}
+        >
+          <Eye className="w-4 h-4" />
+          Preview
+        </button>
+      </div>
+
+      {/* Split view */}
+      <div className="flex flex-1 min-h-0">
+        {/* Config panel — always visible on lg, toggled on mobile */}
+        <div
+          className={`${
+            mobileTab === 'config' ? 'flex' : 'hidden'
+          } lg:flex w-full lg:w-[400px] flex-shrink-0`}
+        >
+          <ConfigPanel />
+        </div>
+
+        {/* Preview panel — always visible on lg, toggled on mobile */}
+        <div
+          className={`${
+            mobileTab === 'preview' ? 'flex' : 'hidden'
+          } lg:flex flex-1 min-w-0`}
+        >
+          <PreviewPanel />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/__tests__/ConfigPanel.test.tsx
+++ b/src/components/admin/appearance/__tests__/ConfigPanel.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfigPanel } from '../config-panel/ConfigPanel';
+import { AppearanceProvider } from '../AppearanceContext';
+import type { AppearanceState } from '../../../../hooks/useAppearanceState';
+
+// Mock framer-motion
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  return {
+    motion: new Proxy({}, {
+      get: (_target: unknown, prop: string) => {
+        return React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+          return React.createElement(prop as string, { ...rest, ref });
+        });
+      },
+    }),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+// Mock TemplateRegistry
+vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
+  getAllTemplates: () => [
+    { id: 'hierarchical', name: 'Hierarchical', description: 'Traditional layout', defaultConfig: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' } },
+    { id: 'metrics-grid', name: 'Metrics Grid', description: 'Flat grid', defaultConfig: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: true, cardVariant: 'compact' } },
+    { id: 'launch-traction', name: 'Launch Traction', description: 'Animated dashboard', defaultConfig: { showSidebar: false, showNarrativeHero: false, gridColumns: 4, enableAnimations: true, cardVariant: 'rich' } },
+  ],
+  getTemplateInfo: (id: string) => {
+    const t: Record<string, unknown> = {
+      hierarchical: { id: 'hierarchical', name: 'Hierarchical', defaultConfig: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' } },
+      'metrics-grid': { id: 'metrics-grid', name: 'Metrics Grid', defaultConfig: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: true, cardVariant: 'compact' } },
+      'launch-traction': { id: 'launch-traction', name: 'Launch Traction', defaultConfig: { showSidebar: false, showNarrativeHero: false, gridColumns: 4, enableAnimations: true, cardVariant: 'rich' } },
+    };
+    return t[id] || t.hierarchical;
+  },
+  getMergedConfig: (templateId: string, customConfig?: Record<string, unknown>) => {
+    const defaults: Record<string, Record<string, unknown>> = {
+      hierarchical: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' },
+      'metrics-grid': { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: true, cardVariant: 'compact' },
+      'launch-traction': { showSidebar: false, showNarrativeHero: false, gridColumns: 4, enableAnimations: true, cardVariant: 'rich' },
+    };
+    return { ...(defaults[templateId] || defaults.hierarchical), ...customConfig };
+  },
+}));
+
+// Mock useImageUpload
+vi.mock('../../../../hooks/useUpload', () => ({
+  useImageUpload: vi.fn(() => ({
+    upload: vi.fn(),
+    isUploading: false,
+    progress: null,
+    error: null,
+    reset: vi.fn(),
+  })),
+}));
+
+const mockDispatch = vi.fn();
+const mockSave = vi.fn();
+
+const defaultState: AppearanceState = {
+  primaryColor: '#0099CC',
+  secondaryColor: '#FFB800',
+  logoUrl: '',
+  dashboardTemplate: 'hierarchical',
+  dashboardConfig: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' },
+  isDirty: false,
+};
+
+function renderConfigPanel(overrides?: Partial<AppearanceState>) {
+  const state = { ...defaultState, ...overrides };
+  return render(
+    <AppearanceProvider
+      value={{
+        state,
+        dispatch: mockDispatch,
+        districtName: 'Test District',
+        districtSlug: 'test-district',
+        save: mockSave,
+        isSaving: false,
+      }}
+    >
+      <ConfigPanel />
+    </AppearanceProvider>
+  );
+}
+
+function expandSection(title: string) {
+  const btn = screen.getByText(title).closest('button');
+  if (btn) fireEvent.click(btn);
+}
+
+describe('ConfigPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Section rendering', () => {
+    it('renders all config sections', () => {
+      renderConfigPanel();
+
+      expect(screen.getByText('Brand Colors')).toBeInTheDocument();
+      expect(screen.getByText('Logo')).toBeInTheDocument();
+      expect(screen.getByText('Dashboard Template')).toBeInTheDocument();
+      expect(screen.getByText('Layout Options')).toBeInTheDocument();
+      expect(screen.getByText('Grid Density')).toBeInTheDocument();
+      expect(screen.getByText('Card Style')).toBeInTheDocument();
+    });
+
+    it('shows save button with Save Changes text', () => {
+      renderConfigPanel();
+
+      expect(screen.getByTestId('appearance-save-btn')).toBeInTheDocument();
+      expect(screen.getByText('Save Changes')).toBeInTheDocument();
+    });
+
+    it('shows Unsaved text when dirty', () => {
+      renderConfigPanel({ isDirty: true });
+      expect(screen.getByText('Unsaved')).toBeInTheDocument();
+    });
+
+    it('does not show Unsaved text when not dirty', () => {
+      renderConfigPanel({ isDirty: false });
+      expect(screen.queryByText('Unsaved')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Color input changes', () => {
+    it('dispatches SET_PRIMARY_COLOR when primary color changes', () => {
+      renderConfigPanel();
+
+      const primaryInput = screen.getByTestId('color-primary-input');
+      fireEvent.change(primaryInput, { target: { value: '#FF0000' } });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_PRIMARY_COLOR', payload: '#FF0000' });
+    });
+
+    it('dispatches SET_SECONDARY_COLOR when secondary color changes', () => {
+      renderConfigPanel();
+
+      const secondaryInput = screen.getByTestId('color-secondary-input');
+      fireEvent.change(secondaryInput, { target: { value: '#00FF00' } });
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_SECONDARY_COLOR', payload: '#00FF00' });
+    });
+  });
+
+  describe('Template selection', () => {
+    it('dispatches SET_TEMPLATE when template is selected', () => {
+      renderConfigPanel();
+
+      const metricsOption = screen.getByTestId('template-option-metrics-grid');
+      fireEvent.click(metricsOption);
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_TEMPLATE', payload: 'metrics-grid' });
+    });
+  });
+
+  describe('Save button', () => {
+    it('calls save when clicked', () => {
+      renderConfigPanel();
+
+      fireEvent.click(screen.getByTestId('appearance-save-btn'));
+      expect(mockSave).toHaveBeenCalled();
+    });
+  });
+
+  describe('Layout options', () => {
+    it('dispatches UPDATE_CONFIG when sidebar toggle is clicked', () => {
+      renderConfigPanel();
+      expandSection('Layout Options');
+
+      const toggle = screen.getByTestId('config-show-sidebar');
+      fireEvent.click(toggle);
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'UPDATE_CONFIG',
+        payload: { showSidebar: false },
+      });
+    });
+  });
+});

--- a/src/components/admin/appearance/__tests__/PreviewPanel.test.tsx
+++ b/src/components/admin/appearance/__tests__/PreviewPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PreviewPanel } from '../preview-panel/PreviewPanel';
+import { AppearanceProvider } from '../AppearanceContext';
+import type { AppearanceState } from '../../../../hooks/useAppearanceState';
+
+// Mock framer-motion
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  return {
+    motion: new Proxy({}, {
+      get: (_target: unknown, prop: string) => {
+        return React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+          return React.createElement(prop as string, { ...rest, ref });
+        });
+      },
+    }),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+// Mock TemplateRegistry
+vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
+  getMergedConfig: (templateId: string, customConfig?: Record<string, unknown>) => {
+    const defaults: Record<string, Record<string, unknown>> = {
+      hierarchical: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' },
+      'metrics-grid': { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: true, cardVariant: 'compact' },
+      'launch-traction': { showSidebar: false, showNarrativeHero: false, gridColumns: 4, enableAnimations: true, cardVariant: 'rich' },
+    };
+    return { ...(defaults[templateId] || defaults.hierarchical), ...customConfig };
+  },
+}));
+
+const mockDispatch = vi.fn();
+const mockSave = vi.fn();
+
+function renderPreviewPanel(overrides?: Partial<AppearanceState>) {
+  const defaultState: AppearanceState = {
+    primaryColor: '#0099CC',
+    secondaryColor: '#FFB800',
+    logoUrl: '',
+    dashboardTemplate: 'hierarchical',
+    dashboardConfig: {},
+    isDirty: false,
+  };
+  const state = { ...defaultState, ...overrides };
+  return render(
+    <AppearanceProvider
+      value={{
+        state,
+        dispatch: mockDispatch,
+        districtName: 'Test District',
+        districtTagline: 'Excellence in Education',
+        districtSlug: 'test-district',
+        save: mockSave,
+        isSaving: false,
+      }}
+    >
+      <PreviewPanel />
+    </AppearanceProvider>
+  );
+}
+
+describe('PreviewPanel', () => {
+  describe('Toolbar', () => {
+    it('shows browser chrome with district URL', () => {
+      renderPreviewPanel();
+      expect(screen.getByText(/test-district\.stratadash\.com/)).toBeInTheDocument();
+    });
+
+    it('shows Live Preview label', () => {
+      renderPreviewPanel();
+      expect(screen.getByText('Live Preview')).toBeInTheDocument();
+    });
+
+    it('shows desktop and mobile toggle buttons', () => {
+      renderPreviewPanel();
+      expect(screen.getByTitle('Desktop preview')).toBeInTheDocument();
+      expect(screen.getByTitle('Mobile preview')).toBeInTheDocument();
+    });
+  });
+
+  describe('Renderer selection', () => {
+    it('renders hierarchical template by default', () => {
+      renderPreviewPanel({ dashboardTemplate: 'hierarchical' });
+      // Hierarchical shows sidebar + PreviewHeader, both contain "STRATEGIC PLAN"
+      const matches = screen.getAllByText('STRATEGIC PLAN');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders metrics-grid template', () => {
+      renderPreviewPanel({ dashboardTemplate: 'metrics-grid' });
+      // Metrics grid shows KPI cards
+      expect(screen.getByText('Graduation Rate')).toBeInTheDocument();
+      expect(screen.getByText('Attendance')).toBeInTheDocument();
+    });
+
+    it('renders launch-traction template with dark theme', () => {
+      renderPreviewPanel({ dashboardTemplate: 'launch-traction' });
+      // Launch traction shows counter items
+      expect(screen.getByText('12,847')).toBeInTheDocument();
+      expect(screen.getByText('Strategic Pillars')).toBeInTheDocument();
+    });
+  });
+
+  describe('Device toggle', () => {
+    it('defaults to desktop mode', () => {
+      renderPreviewPanel();
+      // Desktop button should have active styling
+      const desktopBtn = screen.getByTitle('Desktop preview');
+      expect(desktopBtn.closest('button')).toHaveClass('bg-white');
+    });
+
+    it('can switch to mobile mode', () => {
+      renderPreviewPanel();
+      fireEvent.click(screen.getByTitle('Mobile preview'));
+      const mobileBtn = screen.getByTitle('Mobile preview');
+      expect(mobileBtn.closest('button')).toHaveClass('bg-white');
+    });
+  });
+
+  describe('District name display', () => {
+    it('shows district name in preview', () => {
+      renderPreviewPanel();
+      const matches = screen.getAllByText('Test District');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/src/components/admin/appearance/config-panel/ConfigPanel.tsx
+++ b/src/components/admin/appearance/config-panel/ConfigPanel.tsx
@@ -1,0 +1,35 @@
+import { ConfigPanelHeader } from './ConfigPanelHeader';
+import { ConfigSection } from './ConfigSection';
+import { CONFIG_SECTIONS } from './sections';
+
+export function ConfigPanel() {
+  const sortedSections = [...CONFIG_SECTIONS].sort((a, b) => a.order - b.order);
+
+  return (
+    <div
+      className="flex flex-col w-full h-full border-r"
+      style={{
+        backgroundColor: 'var(--editorial-surface)',
+        borderColor: 'var(--editorial-border)',
+      }}
+    >
+      <ConfigPanelHeader />
+      <div className="flex-1 overflow-y-auto">
+        {sortedSections.map((section) => {
+          const SectionComponent = section.component;
+          const Icon = section.icon;
+          return (
+            <ConfigSection
+              key={section.id}
+              title={section.title}
+              icon={<Icon className="w-4 h-4" />}
+              defaultOpen={section.defaultOpen}
+            >
+              <SectionComponent />
+            </ConfigSection>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/ConfigPanelHeader.tsx
+++ b/src/components/admin/appearance/config-panel/ConfigPanelHeader.tsx
@@ -1,0 +1,67 @@
+import { Save, Loader2 } from 'lucide-react';
+import { useAppearance } from '../AppearanceContext';
+
+export function ConfigPanelHeader() {
+  const { state, save, isSaving } = useAppearance();
+
+  return (
+    <div
+      className="flex items-center justify-between px-6 py-4 border-b flex-shrink-0"
+      style={{ borderColor: 'var(--editorial-border)' }}
+    >
+      <div>
+        <h1
+          className="text-xl font-medium tracking-tight"
+          style={{
+            fontFamily: "'Playfair Display', Georgia, serif",
+            color: 'var(--editorial-text-primary)',
+          }}
+        >
+          Appearance
+        </h1>
+        <p className="text-xs mt-0.5" style={{ color: 'var(--editorial-text-muted)' }}>
+          Customize your district's branding
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {state.isDirty && (
+          <span
+            className="text-xs font-medium"
+            style={{ color: 'var(--editorial-accent-primary)' }}
+          >
+            Unsaved
+          </span>
+        )}
+        <button
+          data-testid="appearance-save-btn"
+          onClick={save}
+          disabled={isSaving}
+          className="relative flex items-center gap-2 px-4 py-2 text-white rounded-lg transition-colors disabled:opacity-50 font-semibold text-sm"
+          style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
+          onMouseEnter={(e) => {
+            if (!isSaving) e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary-hover)';
+          }}
+          onMouseLeave={(e) => {
+            if (!isSaving) e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary)';
+          }}
+        >
+          {state.isDirty && (
+            <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-amber-400 border-2 border-white" />
+          )}
+          {isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save className="h-4 w-4" />
+              Save Changes
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/ConfigSection.tsx
+++ b/src/components/admin/appearance/config-panel/ConfigSection.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ConfigSectionProps {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export function ConfigSection({ title, icon, children, defaultOpen = true }: ConfigSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div
+      className="border-b last:border-b-0"
+      style={{ borderColor: 'var(--editorial-border-light)' }}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full px-6 py-3.5 text-left transition-colors hover:bg-[var(--editorial-surface-alt)]"
+      >
+        <div className="flex items-center gap-2.5">
+          <span style={{ color: 'var(--editorial-accent-primary)' }}>{icon}</span>
+          <span
+            className="text-sm font-semibold"
+            style={{ color: 'var(--editorial-text-primary)' }}
+          >
+            {title}
+          </span>
+        </div>
+        <motion.span
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <ChevronDown className="w-4 h-4" style={{ color: 'var(--editorial-text-muted)' }} />
+        </motion.span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <div className="px-6 pb-5">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/BrandColorsSection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/BrandColorsSection.tsx
@@ -1,0 +1,103 @@
+import { useAppearance } from '../../AppearanceContext';
+
+const PRESET_COLORS = [
+  '#0099CC', '#1E40AF', '#7C3AED', '#059669',
+  '#DC2626', '#EA580C', '#CA8A04', '#0F766E',
+  '#4F46E5', '#BE185D', '#1D4ED8', '#15803D',
+];
+
+function ColorField({
+  label,
+  value,
+  onChange,
+  pickerTestId,
+  inputTestId,
+}: {
+  label: string;
+  value: string;
+  onChange: (color: string) => void;
+  pickerTestId: string;
+  inputTestId: string;
+}) {
+  return (
+    <div>
+      <label
+        className="block text-xs font-medium mb-1.5"
+        style={{ color: 'var(--editorial-text-secondary)' }}
+      >
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          data-testid={pickerTestId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-10 h-10 rounded-lg cursor-pointer flex-shrink-0"
+          style={{ border: '1px solid var(--editorial-border)' }}
+        />
+        <input
+          type="text"
+          data-testid={inputTestId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 px-2.5 py-1.5 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-[var(--editorial-accent-primary)] font-mono"
+          style={{
+            border: '1px solid var(--editorial-border)',
+            color: 'var(--editorial-text-primary)',
+          }}
+          placeholder="#000000"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function BrandColorsSection() {
+  const { state, dispatch } = useAppearance();
+
+  return (
+    <div className="space-y-4">
+      <ColorField
+        label="Primary Color"
+        value={state.primaryColor}
+        onChange={(c) => dispatch({ type: 'SET_PRIMARY_COLOR', payload: c })}
+        pickerTestId="color-primary-picker"
+        inputTestId="color-primary-input"
+      />
+
+      <ColorField
+        label="Secondary Color"
+        value={state.secondaryColor}
+        onChange={(c) => dispatch({ type: 'SET_SECONDARY_COLOR', payload: c })}
+        pickerTestId="color-secondary-picker"
+        inputTestId="color-secondary-input"
+      />
+
+      {/* Preset palette */}
+      <div>
+        <span
+          className="block text-xs font-medium mb-1.5"
+          style={{ color: 'var(--editorial-text-muted)' }}
+        >
+          Quick Picks
+        </span>
+        <div className="flex flex-wrap gap-1.5">
+          {PRESET_COLORS.map((color) => (
+            <button
+              key={color}
+              type="button"
+              onClick={() => dispatch({ type: 'SET_PRIMARY_COLOR', payload: color })}
+              className="w-7 h-7 rounded-md border-2 transition-transform hover:scale-110"
+              style={{
+                backgroundColor: color,
+                borderColor: state.primaryColor === color ? 'var(--editorial-text-primary)' : 'transparent',
+              }}
+              title={color}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/CardStyleSection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/CardStyleSection.tsx
@@ -1,0 +1,46 @@
+import { useAppearance } from '../../AppearanceContext';
+import { getMergedConfig } from '../../../../public/templates/TemplateRegistry';
+import type { DashboardConfig } from '../../../../../lib/types';
+
+const CARD_VARIANTS: { id: NonNullable<DashboardConfig['cardVariant']>; label: string; description: string }[] = [
+  { id: 'default', label: 'Default', description: 'Standard card with border' },
+  { id: 'compact', label: 'Compact', description: 'Smaller cards, dense layout' },
+  { id: 'rich', label: 'Rich', description: 'Elevated cards with shadows' },
+];
+
+export function CardStyleSection() {
+  const { state, dispatch, isSaving } = useAppearance();
+  const merged = getMergedConfig(state.dashboardTemplate, state.dashboardConfig);
+
+  return (
+    <div>
+      <p className="text-xs mb-2.5" style={{ color: 'var(--editorial-text-muted)' }}>
+        Visual style for metric cards
+      </p>
+      <div className="grid grid-cols-3 gap-2">
+        {CARD_VARIANTS.map(({ id, label }) => {
+          const isActive = merged.cardVariant === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              data-testid={`config-card-${id}`}
+              onClick={() => dispatch({ type: 'UPDATE_CONFIG', payload: { cardVariant: id } })}
+              disabled={isSaving}
+              className={`py-2 px-3 rounded-lg text-xs font-medium transition-colors capitalize ${
+                isSaving ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
+              style={{
+                backgroundColor: isActive ? 'var(--editorial-accent-primary)' : 'transparent',
+                color: isActive ? 'white' : 'var(--editorial-text-secondary)',
+                border: isActive ? 'none' : '1px solid var(--editorial-border)',
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/GridDensitySection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/GridDensitySection.tsx
@@ -1,0 +1,58 @@
+import { useAppearance } from '../../AppearanceContext';
+import { getMergedConfig } from '../../../../public/templates/TemplateRegistry';
+
+const GRID_OPTIONS: { cols: 2 | 3 | 4; label: string }[] = [
+  { cols: 2, label: '2 Columns' },
+  { cols: 3, label: '3 Columns' },
+  { cols: 4, label: '4 Columns' },
+];
+
+function MiniGrid({ cols }: { cols: number }) {
+  return (
+    <div className={`grid gap-0.5 w-5 h-4`} style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+      {Array.from({ length: cols * 2 }).map((_, i) => (
+        <div key={i} className="rounded-[1px] bg-current opacity-40" />
+      ))}
+    </div>
+  );
+}
+
+export function GridDensitySection() {
+  const { state, dispatch, isSaving } = useAppearance();
+  const merged = getMergedConfig(state.dashboardTemplate, state.dashboardConfig);
+
+  return (
+    <div>
+      <p className="text-xs mb-2.5" style={{ color: 'var(--editorial-text-muted)' }}>
+        Number of columns on large screens
+      </p>
+      <div className="flex gap-2">
+        {GRID_OPTIONS.map(({ cols, label }) => {
+          const isActive = merged.gridColumns === cols;
+          return (
+            <button
+              key={cols}
+              type="button"
+              data-testid={`config-grid-${cols}`}
+              onClick={() => dispatch({ type: 'UPDATE_CONFIG', payload: { gridColumns: cols } })}
+              disabled={isSaving}
+              className={`flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-lg text-xs font-medium transition-colors ${
+                isActive
+                  ? 'text-white'
+                  : 'hover:bg-[var(--editorial-surface-alt)]'
+              } ${isSaving ? 'opacity-50 cursor-not-allowed' : ''}`}
+              style={{
+                backgroundColor: isActive ? 'var(--editorial-accent-primary)' : 'transparent',
+                color: isActive ? 'white' : 'var(--editorial-text-secondary)',
+                border: isActive ? 'none' : '1px solid var(--editorial-border)',
+              }}
+            >
+              <MiniGrid cols={cols} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/LayoutOptionsSection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/LayoutOptionsSection.tsx
@@ -1,0 +1,89 @@
+import { useAppearance } from '../../AppearanceContext';
+import { getMergedConfig } from '../../../../public/templates/TemplateRegistry';
+
+function Toggle({
+  label,
+  description,
+  checked,
+  onChange,
+  testId,
+  disabled,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  testId: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex items-center justify-between py-2.5 cursor-pointer group">
+      <div className="pr-3">
+        <span
+          className="text-sm font-medium block"
+          style={{ color: 'var(--editorial-text-primary)' }}
+        >
+          {label}
+        </span>
+        <span
+          className="text-xs"
+          style={{ color: 'var(--editorial-text-muted)' }}
+        >
+          {description}
+        </span>
+      </div>
+      <div className="relative flex-shrink-0">
+        <input
+          type="checkbox"
+          data-testid={testId}
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={disabled}
+          className="sr-only peer"
+        />
+        <div
+          className="w-9 h-5 rounded-full transition-colors peer-checked:bg-[var(--editorial-accent-primary)] peer-disabled:opacity-50"
+          style={{ backgroundColor: checked ? 'var(--editorial-accent-primary)' : 'var(--editorial-border)' }}
+        />
+        <div
+          className="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform shadow-sm"
+          style={{ transform: checked ? 'translateX(16px)' : 'translateX(0)' }}
+        />
+      </div>
+    </label>
+  );
+}
+
+export function LayoutOptionsSection() {
+  const { state, dispatch, isSaving } = useAppearance();
+  const merged = getMergedConfig(state.dashboardTemplate, state.dashboardConfig);
+
+  return (
+    <div className="space-y-1">
+      <Toggle
+        label="Show Sidebar"
+        description="Display navigation sidebar with objectives"
+        checked={merged.showSidebar ?? true}
+        onChange={(v) => dispatch({ type: 'UPDATE_CONFIG', payload: { showSidebar: v } })}
+        testId="config-show-sidebar"
+        disabled={isSaving}
+      />
+      <Toggle
+        label="Show Hero Section"
+        description="Display title and description at top of dashboard"
+        checked={merged.showNarrativeHero ?? true}
+        onChange={(v) => dispatch({ type: 'UPDATE_CONFIG', payload: { showNarrativeHero: v } })}
+        testId="config-show-hero"
+        disabled={isSaving}
+      />
+      <Toggle
+        label="Enable Animations"
+        description="Animate cards and charts on load"
+        checked={merged.enableAnimations ?? false}
+        onChange={(v) => dispatch({ type: 'UPDATE_CONFIG', payload: { enableAnimations: v } })}
+        testId="config-enable-animations"
+        disabled={isSaving}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/LogoSection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/LogoSection.tsx
@@ -1,0 +1,17 @@
+import { useAppearance } from '../../AppearanceContext';
+import { LogoUpload } from '../../../LogoUpload';
+
+export function LogoSection() {
+  const { state, dispatch } = useAppearance();
+
+  return (
+    <LogoUpload
+      currentUrl={state.logoUrl}
+      onUpload={(url) => dispatch({ type: 'SET_LOGO_URL', payload: url })}
+      onRemove={() => dispatch({ type: 'SET_LOGO_URL', payload: '' })}
+      folder="district-logos"
+      label="District Logo"
+      helpText="PNG, JPG, SVG or WebP. Max 5MB."
+    />
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/TemplateSelectorSection.tsx
+++ b/src/components/admin/appearance/config-panel/sections/TemplateSelectorSection.tsx
@@ -1,0 +1,19 @@
+import { useAppearance } from '../../AppearanceContext';
+import { TemplateSelector } from '../../../TemplateSelector';
+
+export function TemplateSelectorSection() {
+  const { state, dispatch, isSaving } = useAppearance();
+
+  return (
+    <div>
+      <p className="text-xs mb-3" style={{ color: 'var(--editorial-text-muted)' }}>
+        Choose how your public dashboard looks
+      </p>
+      <TemplateSelector
+        value={state.dashboardTemplate}
+        onChange={(template) => dispatch({ type: 'SET_TEMPLATE', payload: template })}
+        disabled={isSaving}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/appearance/config-panel/sections/index.ts
+++ b/src/components/admin/appearance/config-panel/sections/index.ts
@@ -1,0 +1,26 @@
+import type { ComponentType } from 'react';
+import { Palette, ImageIcon, LayoutTemplate, SlidersHorizontal, Grid3X3, CreditCard } from 'lucide-react';
+import { BrandColorsSection } from './BrandColorsSection';
+import { LogoSection } from './LogoSection';
+import { TemplateSelectorSection } from './TemplateSelectorSection';
+import { LayoutOptionsSection } from './LayoutOptionsSection';
+import { GridDensitySection } from './GridDensitySection';
+import { CardStyleSection } from './CardStyleSection';
+
+export interface ConfigSectionEntry {
+  id: string;
+  title: string;
+  icon: ComponentType<{ className?: string }>;
+  order: number;
+  component: ComponentType;
+  defaultOpen?: boolean;
+}
+
+export const CONFIG_SECTIONS: ConfigSectionEntry[] = [
+  { id: 'colors', title: 'Brand Colors', icon: Palette, order: 0, component: BrandColorsSection, defaultOpen: true },
+  { id: 'logo', title: 'Logo', icon: ImageIcon, order: 1, component: LogoSection, defaultOpen: true },
+  { id: 'template', title: 'Dashboard Template', icon: LayoutTemplate, order: 2, component: TemplateSelectorSection, defaultOpen: true },
+  { id: 'layout', title: 'Layout Options', icon: SlidersHorizontal, order: 3, component: LayoutOptionsSection, defaultOpen: false },
+  { id: 'grid', title: 'Grid Density', icon: Grid3X3, order: 4, component: GridDensitySection, defaultOpen: false },
+  { id: 'cards', title: 'Card Style', icon: CreditCard, order: 5, component: CardStyleSection, defaultOpen: false },
+];

--- a/src/components/admin/appearance/index.ts
+++ b/src/components/admin/appearance/index.ts
@@ -1,0 +1,2 @@
+export { AppearanceEditor } from './AppearanceEditor';
+export { AppearanceProvider, useAppearance } from './AppearanceContext';

--- a/src/components/admin/appearance/preview-panel/PreviewPanel.tsx
+++ b/src/components/admin/appearance/preview-panel/PreviewPanel.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+import { PreviewToolbar, type DeviceMode } from './PreviewToolbar';
+import { PreviewViewport } from './PreviewViewport';
+
+export function PreviewPanel() {
+  const [device, setDevice] = useState<DeviceMode>('desktop');
+
+  return (
+    <div className="flex flex-col w-full h-full min-w-0">
+      <PreviewToolbar device={device} onDeviceChange={setDevice} />
+      <PreviewViewport device={device} />
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/PreviewToolbar.tsx
+++ b/src/components/admin/appearance/preview-panel/PreviewToolbar.tsx
@@ -1,0 +1,83 @@
+import { Monitor, Smartphone } from 'lucide-react';
+import { useAppearance } from '../AppearanceContext';
+
+export type DeviceMode = 'desktop' | 'mobile';
+
+interface PreviewToolbarProps {
+  device: DeviceMode;
+  onDeviceChange: (device: DeviceMode) => void;
+}
+
+export function PreviewToolbar({ device, onDeviceChange }: PreviewToolbarProps) {
+  const { districtSlug } = useAppearance();
+
+  return (
+    <div
+      className="flex items-center justify-between px-4 py-2 border-b flex-shrink-0"
+      style={{
+        backgroundColor: 'var(--editorial-surface)',
+        borderColor: 'var(--editorial-border)',
+      }}
+    >
+      {/* Browser chrome dots */}
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-red-400" />
+          <div className="w-2.5 h-2.5 rounded-full bg-yellow-400" />
+          <div className="w-2.5 h-2.5 rounded-full bg-green-400" />
+        </div>
+        <div
+          className="px-3 py-1 rounded text-xs font-mono truncate max-w-[240px]"
+          style={{
+            backgroundColor: 'var(--editorial-surface-alt)',
+            color: 'var(--editorial-text-muted)',
+          }}
+        >
+          https://{districtSlug}.stratadash.com
+        </div>
+      </div>
+
+      {/* Device toggle + Live label */}
+      <div className="flex items-center gap-3">
+        <span
+          className="flex items-center gap-1.5 text-xs font-medium"
+          style={{ color: 'var(--editorial-accent-success)' }}
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-current animate-pulse" />
+          Live Preview
+        </span>
+        <div
+          className="flex rounded-lg p-0.5"
+          style={{ backgroundColor: 'var(--editorial-surface-alt)' }}
+        >
+          <button
+            type="button"
+            onClick={() => onDeviceChange('desktop')}
+            className={`p-1.5 rounded-md transition-colors ${
+              device === 'desktop' ? 'bg-white shadow-sm' : ''
+            }`}
+            title="Desktop preview"
+          >
+            <Monitor
+              className="w-4 h-4"
+              style={{ color: device === 'desktop' ? 'var(--editorial-text-primary)' : 'var(--editorial-text-muted)' }}
+            />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDeviceChange('mobile')}
+            className={`p-1.5 rounded-md transition-colors ${
+              device === 'mobile' ? 'bg-white shadow-sm' : ''
+            }`}
+            title="Mobile preview"
+          >
+            <Smartphone
+              className="w-4 h-4"
+              style={{ color: device === 'mobile' ? 'var(--editorial-text-primary)' : 'var(--editorial-text-muted)' }}
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/PreviewViewport.tsx
+++ b/src/components/admin/appearance/preview-panel/PreviewViewport.tsx
@@ -1,0 +1,66 @@
+import { motion } from 'framer-motion';
+import { useAppearance } from '../AppearanceContext';
+import { RENDERER_REGISTRY } from './renderers';
+import { getMergedConfig } from '../../../public/templates/TemplateRegistry';
+import type { DeviceMode } from './PreviewToolbar';
+
+interface PreviewViewportProps {
+  device: DeviceMode;
+}
+
+export function PreviewViewport({ device }: PreviewViewportProps) {
+  const { state, districtName, districtTagline } = useAppearance();
+  const mergedConfig = getMergedConfig(state.dashboardTemplate, state.dashboardConfig);
+  const Renderer = RENDERER_REGISTRY[state.dashboardTemplate] || RENDERER_REGISTRY.hierarchical;
+
+  const isMobile = device === 'mobile';
+
+  return (
+    <div
+      className="flex-1 flex items-start justify-center overflow-auto p-6"
+      style={{ backgroundColor: 'var(--editorial-bg)' }}
+    >
+      <motion.div
+        layout
+        transition={{ duration: 0.3, ease: 'easeInOut' }}
+        className={`origin-top ${
+          isMobile
+            ? 'w-[375px] rounded-[2rem] border-[8px] border-slate-800 shadow-2xl'
+            : 'w-full max-w-[1200px] rounded-lg border shadow-lg'
+        }`}
+        style={{
+          borderColor: isMobile ? undefined : 'var(--editorial-border)',
+        }}
+      >
+        <div
+          className={`overflow-hidden bg-white ${
+            isMobile ? 'rounded-[1.5rem]' : 'rounded-lg'
+          }`}
+          style={isMobile ? { height: '667px', overflowY: 'auto' } : {}}
+        >
+          <div
+            style={
+              isMobile
+                ? {}
+                : {
+                    transform: 'scale(0.55)',
+                    transformOrigin: 'top left',
+                    width: `${100 / 0.55}%`,
+                    height: `${100 / 0.55}%`,
+                  }
+            }
+          >
+            <Renderer
+              primaryColor={state.primaryColor}
+              secondaryColor={state.secondaryColor}
+              logoUrl={state.logoUrl}
+              districtName={districtName}
+              tagline={districtTagline}
+              config={mergedConfig}
+            />
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/renderers/HierarchicalRenderer.tsx
+++ b/src/components/admin/appearance/preview-panel/renderers/HierarchicalRenderer.tsx
@@ -1,0 +1,58 @@
+import { PreviewHeader } from '../../../preview/PreviewHeader';
+import { PreviewHero } from '../../../preview/PreviewHero';
+import { PreviewObjectiveCard } from '../../../preview/PreviewObjectiveCard';
+import type { PreviewRendererProps } from './index';
+
+export function HierarchicalRenderer({
+  primaryColor,
+  secondaryColor,
+  logoUrl,
+  districtName,
+  tagline,
+  config,
+}: PreviewRendererProps) {
+  return (
+    <div className="flex min-h-full">
+      {/* Optional sidebar */}
+      {config.showSidebar && (
+        <aside className="w-56 bg-slate-900 text-white flex-shrink-0">
+          <div className="p-4 border-b border-slate-700">
+            <div className="text-sm font-bold tracking-wide" style={{ color: primaryColor }}>
+              STRATEGIC PLAN
+            </div>
+          </div>
+          <nav className="p-3 space-y-1">
+            {['Overview', 'Student Achievement', 'Community', 'Staff Development'].map((item, i) => (
+              <div
+                key={item}
+                className={`px-3 py-2 rounded text-sm ${
+                  i === 0 ? 'font-medium' : 'text-slate-400'
+                }`}
+                style={i === 0 ? { backgroundColor: `${primaryColor}20`, color: primaryColor } : {}}
+              >
+                {item}
+              </div>
+            ))}
+          </nav>
+        </aside>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        <PreviewHeader
+          primaryColor={primaryColor}
+          districtName={districtName}
+          tagline={tagline}
+          logoUrl={logoUrl}
+        />
+        {config.showNarrativeHero && (
+          <PreviewHero primaryColor={primaryColor} districtName={districtName} />
+        )}
+        <PreviewObjectiveCard
+          primaryColor={primaryColor}
+          secondaryColor={secondaryColor}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/renderers/LaunchTractionRenderer.tsx
+++ b/src/components/admin/appearance/preview-panel/renderers/LaunchTractionRenderer.tsx
@@ -1,0 +1,133 @@
+import { motion } from 'framer-motion';
+import type { PreviewRendererProps } from './index';
+
+const COUNTER_ITEMS = [
+  { label: 'Students Served', value: '12,847' },
+  { label: 'Schools', value: '24' },
+  { label: 'Goals On Track', value: '87%' },
+  { label: 'Community Events', value: '156' },
+];
+
+const CARD_ITEMS = [
+  { title: 'Student Achievement', progress: 82 },
+  { title: 'Community Partnerships', progress: 64 },
+  { title: 'Staff Development', progress: 91 },
+  { title: 'Operational Excellence', progress: 73 },
+];
+
+export function LaunchTractionRenderer({
+  primaryColor,
+  secondaryColor,
+  districtName,
+  config,
+}: PreviewRendererProps) {
+  const animate = config.enableAnimations;
+  const cols = config.gridColumns ?? 4;
+
+  return (
+    <div className="min-h-full bg-slate-900 text-white">
+      {/* Header bar */}
+      <div className="px-8 py-4 flex items-center justify-between border-b border-slate-700">
+        <div>
+          <h1 className="text-xl font-bold">{districtName}</h1>
+          <p className="text-slate-400 text-sm">Strategic Plan Dashboard</p>
+        </div>
+        <div
+          className="px-3 py-1.5 rounded-lg text-sm font-semibold"
+          style={{ backgroundColor: primaryColor }}
+        >
+          2025-2026
+        </div>
+      </div>
+
+      {/* Counter row */}
+      <div className="px-8 py-8">
+        <div
+          className="grid gap-6"
+          style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+        >
+          {COUNTER_ITEMS.map((item, i) => (
+            <motion.div
+              key={item.label}
+              initial={animate ? { opacity: 0, y: 20 } : false}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.1 }}
+              className="text-center p-4 rounded-xl bg-slate-800 border border-slate-700"
+            >
+              <div
+                className="text-3xl font-bold mb-1"
+                style={{ color: i === 0 ? primaryColor : i === 1 ? secondaryColor : 'white' }}
+              >
+                {item.value}
+              </div>
+              <div className="text-xs text-slate-400 uppercase tracking-wider">
+                {item.label}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Progress cards */}
+      <div className="px-8 pb-8">
+        <h2 className="text-lg font-semibold mb-4">Strategic Pillars</h2>
+        <div
+          className="grid gap-4"
+          style={{ gridTemplateColumns: `repeat(${Math.min(cols, CARD_ITEMS.length)}, 1fr)` }}
+        >
+          {CARD_ITEMS.map((card, i) => (
+            <motion.div
+              key={card.title}
+              initial={animate ? { opacity: 0, scale: 0.95 } : false}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 0.3 + i * 0.08 }}
+              className="p-4 rounded-xl bg-slate-800 border border-slate-700"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm font-medium text-slate-200">{card.title}</span>
+                <span className="text-sm font-bold" style={{ color: primaryColor }}>
+                  {card.progress}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-slate-700 overflow-hidden">
+                <motion.div
+                  className="h-full rounded-full"
+                  style={{ backgroundColor: primaryColor }}
+                  initial={animate ? { width: 0 } : { width: `${card.progress}%` }}
+                  animate={{ width: `${card.progress}%` }}
+                  transition={{ duration: 0.8, delay: 0.5 + i * 0.1 }}
+                />
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Mock bar chart area */}
+      <div className="px-8 pb-8">
+        <div className="rounded-xl bg-slate-800 border border-slate-700 p-6">
+          <h3 className="text-sm font-semibold mb-4 text-slate-300">Year-over-Year Progress</h3>
+          <div className="flex items-end gap-3 h-24">
+            {[45, 58, 62, 71, 82, 87].map((h, i) => (
+              <motion.div
+                key={i}
+                className="flex-1 rounded-t"
+                style={{ backgroundColor: i === 5 ? primaryColor : `${primaryColor}60` }}
+                initial={animate ? { height: 0 } : { height: `${h}%` }}
+                animate={{ height: `${h}%` }}
+                transition={{ duration: 0.5, delay: 0.8 + i * 0.08 }}
+              />
+            ))}
+          </div>
+          <div className="flex gap-3 mt-2">
+            {['2020', '2021', '2022', '2023', '2024', '2025'].map((yr) => (
+              <span key={yr} className="flex-1 text-center text-[10px] text-slate-500">
+                {yr}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/renderers/MetricsGridRenderer.tsx
+++ b/src/components/admin/appearance/preview-panel/renderers/MetricsGridRenderer.tsx
@@ -1,0 +1,104 @@
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { PreviewHeader } from '../../../preview/PreviewHeader';
+import type { PreviewRendererProps } from './index';
+
+const SAMPLE_METRICS = [
+  { label: 'Graduation Rate', value: '94.2%', trend: 'up' as const, delta: '+2.1%' },
+  { label: 'Attendance', value: '96.8%', trend: 'up' as const, delta: '+0.4%' },
+  { label: 'Reading Proficiency', value: '78.5%', trend: 'down' as const, delta: '-1.2%' },
+  { label: 'Math Proficiency', value: '71.3%', trend: 'up' as const, delta: '+3.6%' },
+  { label: 'Parent Satisfaction', value: '4.2/5', trend: 'stable' as const, delta: '0.0' },
+  { label: 'Teacher Retention', value: '89.1%', trend: 'up' as const, delta: '+1.8%' },
+];
+
+const TrendIcon = ({ trend }: { trend: 'up' | 'down' | 'stable' }) => {
+  if (trend === 'up') return <TrendingUp className="w-3 h-3 text-green-500" />;
+  if (trend === 'down') return <TrendingDown className="w-3 h-3 text-red-500" />;
+  return <Minus className="w-3 h-3 text-slate-400" />;
+};
+
+export function MetricsGridRenderer({
+  primaryColor,
+  secondaryColor,
+  logoUrl,
+  districtName,
+  tagline,
+  config,
+}: PreviewRendererProps) {
+  const cols = config.gridColumns ?? 3;
+  const variant = config.cardVariant ?? 'compact';
+
+  return (
+    <div className="min-h-full">
+      <PreviewHeader
+        primaryColor={primaryColor}
+        districtName={districtName}
+        tagline={tagline}
+        logoUrl={logoUrl}
+      />
+
+      {config.showNarrativeHero && (
+        <div className="py-8 text-center" style={{ backgroundColor: `${primaryColor}08` }}>
+          <h2 className="text-2xl font-bold text-slate-900">Key Performance Indicators</h2>
+          <p className="text-slate-500 mt-1">Real-time district metrics at a glance</p>
+        </div>
+      )}
+
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <div
+          className="grid gap-4"
+          style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+        >
+          {SAMPLE_METRICS.map((metric) => (
+            <div
+              key={metric.label}
+              className={`rounded-xl ${
+                variant === 'rich'
+                  ? 'shadow-md border-0'
+                  : variant === 'compact'
+                    ? 'border'
+                    : 'border shadow-sm'
+              }`}
+              style={{
+                backgroundColor: 'white',
+                borderColor: variant !== 'rich' ? '#e5e7eb' : undefined,
+              }}
+            >
+              <div className={variant === 'compact' ? 'p-3' : 'p-5'}>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">
+                    {metric.label}
+                  </span>
+                  <TrendIcon trend={metric.trend} />
+                </div>
+                <div className="flex items-end gap-2">
+                  <span
+                    className={`font-bold ${variant === 'compact' ? 'text-xl' : 'text-2xl'}`}
+                    style={{ color: primaryColor }}
+                  >
+                    {metric.value}
+                  </span>
+                  <span
+                    className={`text-xs font-medium mb-0.5 ${
+                      metric.trend === 'up' ? 'text-green-600' : metric.trend === 'down' ? 'text-red-600' : 'text-slate-400'
+                    }`}
+                  >
+                    {metric.delta}
+                  </span>
+                </div>
+                {variant === 'rich' && (
+                  <div className="mt-3 h-1.5 rounded-full bg-slate-100 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: '70%', backgroundColor: secondaryColor }}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/appearance/preview-panel/renderers/index.ts
+++ b/src/components/admin/appearance/preview-panel/renderers/index.ts
@@ -1,0 +1,20 @@
+import type { ComponentType } from 'react';
+import type { DashboardTemplate, DashboardConfig } from '../../../../../lib/types';
+import { HierarchicalRenderer } from './HierarchicalRenderer';
+import { MetricsGridRenderer } from './MetricsGridRenderer';
+import { LaunchTractionRenderer } from './LaunchTractionRenderer';
+
+export interface PreviewRendererProps {
+  primaryColor: string;
+  secondaryColor: string;
+  logoUrl: string;
+  districtName: string;
+  tagline?: string;
+  config: DashboardConfig;
+}
+
+export const RENDERER_REGISTRY: Record<DashboardTemplate, ComponentType<PreviewRendererProps>> = {
+  hierarchical: HierarchicalRenderer,
+  'metrics-grid': MetricsGridRenderer,
+  'launch-traction': LaunchTractionRenderer,
+};

--- a/src/components/admin/preview/PreviewHeader.tsx
+++ b/src/components/admin/preview/PreviewHeader.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { User, Globe, GraduationCap, ChevronDown, Settings } from 'lucide-react';
 
 interface PreviewHeaderProps {
@@ -17,6 +18,8 @@ export function PreviewHeader({
   tagline = 'Community. Innovation. Excellence.',
   logoUrl,
 }: PreviewHeaderProps) {
+  const [imgError, setImgError] = useState(false);
+
   return (
     <header>
       {/* Top Navigation Bar */}
@@ -50,12 +53,13 @@ export function PreviewHeader({
           <div className="flex justify-between items-center py-4">
             {/* Logo and District Name */}
             <div className="flex items-center space-x-4">
-              {logoUrl ? (
+              {logoUrl && !imgError ? (
                 <div className="w-16 h-16 bg-white rounded-lg p-2 flex items-center justify-center">
                   <img
                     src={logoUrl}
                     alt={`${districtName} Logo`}
                     className="w-full h-full object-contain"
+                    onError={() => setImgError(true)}
                   />
                 </div>
               ) : (

--- a/src/hooks/__tests__/useAppearanceState.test.ts
+++ b/src/hooks/__tests__/useAppearanceState.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest';
+import { appearanceReducer, defaultState, type AppearanceState, type AppearanceAction } from '../useAppearanceState';
+
+// Mock TemplateRegistry for SET_TEMPLATE action
+vi.mock('../../components/public/templates/TemplateRegistry', () => ({
+  getMergedConfig: (templateId: string) => {
+    const configs: Record<string, Record<string, unknown>> = {
+      hierarchical: { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: false, cardVariant: 'default' },
+      'metrics-grid': { showSidebar: true, showNarrativeHero: true, gridColumns: 3, enableAnimations: true, cardVariant: 'compact' },
+      'launch-traction': { showSidebar: false, showNarrativeHero: false, gridColumns: 4, enableAnimations: true, cardVariant: 'rich' },
+    };
+    return configs[templateId] || configs.hierarchical;
+  },
+}));
+
+describe('appearanceReducer', () => {
+  const baseState: AppearanceState = {
+    primaryColor: '#0099CC',
+    secondaryColor: '#FFB800',
+    logoUrl: '',
+    dashboardTemplate: 'hierarchical',
+    dashboardConfig: {},
+    isDirty: false,
+  };
+
+  describe('SET_PRIMARY_COLOR', () => {
+    it('updates primary color and marks dirty', () => {
+      const result = appearanceReducer(baseState, { type: 'SET_PRIMARY_COLOR', payload: '#FF0000' });
+      expect(result.primaryColor).toBe('#FF0000');
+      expect(result.isDirty).toBe(true);
+    });
+
+    it('preserves other state', () => {
+      const result = appearanceReducer(baseState, { type: 'SET_PRIMARY_COLOR', payload: '#FF0000' });
+      expect(result.secondaryColor).toBe('#FFB800');
+      expect(result.dashboardTemplate).toBe('hierarchical');
+    });
+  });
+
+  describe('SET_SECONDARY_COLOR', () => {
+    it('updates secondary color and marks dirty', () => {
+      const result = appearanceReducer(baseState, { type: 'SET_SECONDARY_COLOR', payload: '#00FF00' });
+      expect(result.secondaryColor).toBe('#00FF00');
+      expect(result.isDirty).toBe(true);
+    });
+  });
+
+  describe('SET_LOGO_URL', () => {
+    it('updates logo URL and marks dirty', () => {
+      const result = appearanceReducer(baseState, { type: 'SET_LOGO_URL', payload: 'https://example.com/logo.png' });
+      expect(result.logoUrl).toBe('https://example.com/logo.png');
+      expect(result.isDirty).toBe(true);
+    });
+
+    it('can clear logo URL', () => {
+      const stateWithLogo = { ...baseState, logoUrl: 'https://example.com/logo.png' };
+      const result = appearanceReducer(stateWithLogo, { type: 'SET_LOGO_URL', payload: '' });
+      expect(result.logoUrl).toBe('');
+      expect(result.isDirty).toBe(true);
+    });
+  });
+
+  describe('SET_TEMPLATE', () => {
+    it('updates template and applies defaults', () => {
+      const result = appearanceReducer(baseState, { type: 'SET_TEMPLATE', payload: 'launch-traction' });
+      expect(result.dashboardTemplate).toBe('launch-traction');
+      expect(result.dashboardConfig).toEqual({
+        showSidebar: false,
+        showNarrativeHero: false,
+        gridColumns: 4,
+        enableAnimations: true,
+        cardVariant: 'rich',
+      });
+      expect(result.isDirty).toBe(true);
+    });
+
+    it('replaces existing config with template defaults', () => {
+      const stateWithConfig = {
+        ...baseState,
+        dashboardConfig: { showSidebar: false, gridColumns: 2 as const },
+      };
+      const result = appearanceReducer(stateWithConfig, { type: 'SET_TEMPLATE', payload: 'metrics-grid' });
+      expect(result.dashboardConfig).toEqual({
+        showSidebar: true,
+        showNarrativeHero: true,
+        gridColumns: 3,
+        enableAnimations: true,
+        cardVariant: 'compact',
+      });
+    });
+  });
+
+  describe('UPDATE_CONFIG', () => {
+    it('merges partial config and marks dirty', () => {
+      const result = appearanceReducer(baseState, { type: 'UPDATE_CONFIG', payload: { showSidebar: false } });
+      expect(result.dashboardConfig).toEqual({ showSidebar: false });
+      expect(result.isDirty).toBe(true);
+    });
+
+    it('preserves existing config keys', () => {
+      const stateWithConfig = {
+        ...baseState,
+        dashboardConfig: { showSidebar: true, gridColumns: 3 as const },
+      };
+      const result = appearanceReducer(stateWithConfig, { type: 'UPDATE_CONFIG', payload: { gridColumns: 4 } });
+      expect(result.dashboardConfig).toEqual({ showSidebar: true, gridColumns: 4 });
+    });
+  });
+
+  describe('INIT', () => {
+    it('initializes state from district data', () => {
+      const dirtyState: AppearanceState = {
+        ...baseState,
+        primaryColor: '#CHANGED',
+        isDirty: true,
+      };
+      const result = appearanceReducer(dirtyState, {
+        type: 'INIT',
+        payload: {
+          primaryColor: '#112233',
+          secondaryColor: '#445566',
+          logoUrl: 'https://example.com/logo.png',
+          dashboardTemplate: 'metrics-grid',
+          dashboardConfig: { gridColumns: 4 },
+        },
+      });
+      expect(result.primaryColor).toBe('#112233');
+      expect(result.secondaryColor).toBe('#445566');
+      expect(result.logoUrl).toBe('https://example.com/logo.png');
+      expect(result.dashboardTemplate).toBe('metrics-grid');
+      expect(result.dashboardConfig).toEqual({ gridColumns: 4 });
+      expect(result.isDirty).toBe(false);
+    });
+
+    it('uses defaults for missing fields', () => {
+      const result = appearanceReducer(baseState, { type: 'INIT', payload: {} });
+      expect(result.primaryColor).toBe(defaultState.primaryColor);
+      expect(result.secondaryColor).toBe(defaultState.secondaryColor);
+      expect(result.isDirty).toBe(false);
+    });
+  });
+
+  describe('SAVED', () => {
+    it('clears isDirty flag', () => {
+      const dirtyState: AppearanceState = { ...baseState, isDirty: true };
+      const result = appearanceReducer(dirtyState, { type: 'SAVED' });
+      expect(result.isDirty).toBe(false);
+    });
+
+    it('preserves all other state', () => {
+      const dirtyState: AppearanceState = {
+        ...baseState,
+        primaryColor: '#AABBCC',
+        isDirty: true,
+      };
+      const result = appearanceReducer(dirtyState, { type: 'SAVED' });
+      expect(result.primaryColor).toBe('#AABBCC');
+    });
+  });
+
+  describe('unknown action', () => {
+    it('returns current state', () => {
+      const result = appearanceReducer(baseState, { type: 'UNKNOWN' } as unknown as AppearanceAction);
+      expect(result).toBe(baseState);
+    });
+  });
+});

--- a/src/hooks/useAppearanceState.ts
+++ b/src/hooks/useAppearanceState.ts
@@ -1,0 +1,94 @@
+import { useReducer, useCallback } from 'react';
+import type { DashboardTemplate, DashboardConfig, District } from '../lib/types';
+import { getMergedConfig } from '../components/public/templates/TemplateRegistry';
+
+export interface AppearanceState {
+  primaryColor: string;
+  secondaryColor: string;
+  logoUrl: string;
+  dashboardTemplate: DashboardTemplate;
+  dashboardConfig: DashboardConfig;
+  isDirty: boolean;
+}
+
+export type AppearanceAction =
+  | { type: 'SET_PRIMARY_COLOR'; payload: string }
+  | { type: 'SET_SECONDARY_COLOR'; payload: string }
+  | { type: 'SET_LOGO_URL'; payload: string }
+  | { type: 'SET_TEMPLATE'; payload: DashboardTemplate }
+  | { type: 'UPDATE_CONFIG'; payload: Partial<DashboardConfig> }
+  | { type: 'INIT'; payload: Partial<AppearanceState> }
+  | { type: 'SAVED' };
+
+const defaultState: AppearanceState = {
+  primaryColor: '#0099CC',
+  secondaryColor: '#FFB800',
+  logoUrl: '',
+  dashboardTemplate: 'hierarchical',
+  dashboardConfig: {},
+  isDirty: false,
+};
+
+function appearanceReducer(state: AppearanceState, action: AppearanceAction): AppearanceState {
+  switch (action.type) {
+    case 'SET_PRIMARY_COLOR':
+      return { ...state, primaryColor: action.payload, isDirty: true };
+    case 'SET_SECONDARY_COLOR':
+      return { ...state, secondaryColor: action.payload, isDirty: true };
+    case 'SET_LOGO_URL':
+      return { ...state, logoUrl: action.payload, isDirty: true };
+    case 'SET_TEMPLATE': {
+      const templateDefaults = getMergedConfig(action.payload);
+      return {
+        ...state,
+        dashboardTemplate: action.payload,
+        dashboardConfig: templateDefaults,
+        isDirty: true,
+      };
+    }
+    case 'UPDATE_CONFIG':
+      return {
+        ...state,
+        dashboardConfig: { ...state.dashboardConfig, ...action.payload },
+        isDirty: true,
+      };
+    case 'INIT':
+      return { ...defaultState, ...action.payload, isDirty: false };
+    case 'SAVED':
+      return { ...state, isDirty: false };
+    default:
+      return state;
+  }
+}
+
+export function useAppearanceState(district: District | null | undefined) {
+  const initialState: AppearanceState = district
+    ? {
+        primaryColor: district.primary_color || '#0099CC',
+        secondaryColor: district.secondary_color || '#FFB800',
+        logoUrl: district.logo_url || '',
+        dashboardTemplate: district.dashboard_template || 'hierarchical',
+        dashboardConfig: district.dashboard_config || {},
+        isDirty: false,
+      }
+    : defaultState;
+
+  const [state, dispatch] = useReducer(appearanceReducer, initialState);
+
+  const initFromDistrict = useCallback((d: District) => {
+    dispatch({
+      type: 'INIT',
+      payload: {
+        primaryColor: d.primary_color || '#0099CC',
+        secondaryColor: d.secondary_color || '#FFB800',
+        logoUrl: d.logo_url || '',
+        dashboardTemplate: d.dashboard_template || 'hierarchical',
+        dashboardConfig: d.dashboard_config || {},
+      },
+    });
+  }, []);
+
+  return { state, dispatch, initFromDistrict };
+}
+
+export { appearanceReducer, defaultState };

--- a/src/pages/client/admin/DistrictAppearance.tsx
+++ b/src/pages/client/admin/DistrictAppearance.tsx
@@ -1,57 +1,46 @@
-import { useState, useEffect } from 'react';
-import { Palette, ImageIcon, Save, Loader2, LayoutTemplate } from 'lucide-react';
+import { useEffect, useCallback } from 'react';
 import { useSubdomain } from '../../../contexts/SubdomainContext';
 import { useDistrict, useUpdateDistrict } from '../../../hooks/useDistricts';
-import { LogoUpload } from '../../../components/admin/LogoUpload';
-import { TemplateSelector } from '../../../components/admin/TemplateSelector';
-import { TemplateConfigEditor } from '../../../components/admin/TemplateConfigEditor';
-import { AppearancePreview } from '../../../components/admin/preview';
-import type { DashboardTemplate, DashboardConfig } from '../../../lib/types';
+import { useAppearanceState } from '../../../hooks/useAppearanceState';
+import { AppearanceProvider } from '../../../components/admin/appearance/AppearanceContext';
+import { AppearanceEditor } from '../../../components/admin/appearance/AppearanceEditor';
 
 /**
- * DistrictAppearance - Customize district branding and appearance
- * Restyled with editorial warm paper aesthetic
+ * DistrictAppearance — Thin orchestrator: fetches district, wires up state + context,
+ * delegates rendering to AppearanceEditor (split-view WYSIWYG).
  */
 export function DistrictAppearance() {
   const { slug } = useSubdomain();
   const { data: district, isLoading: districtLoading } = useDistrict(slug || '');
   const updateDistrict = useUpdateDistrict();
+  const { state, dispatch, initFromDistrict } = useAppearanceState(district);
 
-  const [primaryColor, setPrimaryColor] = useState('#0099CC');
-  const [secondaryColor, setSecondaryColor] = useState('#FFB800');
-  const [logoUrl, setLogoUrl] = useState('');
-  const [dashboardTemplate, setDashboardTemplate] = useState<DashboardTemplate>('hierarchical');
-  const [dashboardConfig, setDashboardConfig] = useState<DashboardConfig>({});
-
-  // Initialize form with district data
+  // Re-init when district data arrives or changes
   useEffect(() => {
     if (district) {
-      setPrimaryColor(district.primary_color || '#0099CC');
-      setSecondaryColor(district.secondary_color || '#FFB800');
-      setLogoUrl(district.logo_url || '');
-      setDashboardTemplate(district.dashboard_template || 'hierarchical');
-      setDashboardConfig(district.dashboard_config || {});
+      initFromDistrict(district);
     }
-  }, [district]);
+  }, [district, initFromDistrict]);
 
-  const handleSave = async () => {
+  const save = useCallback(async () => {
     if (!district) return;
 
     try {
       await updateDistrict.mutateAsync({
         id: district.id,
         updates: {
-          primary_color: primaryColor,
-          secondary_color: secondaryColor,
-          logo_url: logoUrl || undefined,
-          dashboard_template: dashboardTemplate,
-          dashboard_config: dashboardConfig,
+          primary_color: state.primaryColor,
+          secondary_color: state.secondaryColor,
+          logo_url: state.logoUrl || undefined,
+          dashboard_template: state.dashboardTemplate,
+          dashboard_config: state.dashboardConfig,
         },
       });
+      dispatch({ type: 'SAVED' });
     } catch (error) {
       console.error('Failed to update district:', error);
     }
-  };
+  }, [district, state, updateDistrict, dispatch]);
 
   if (districtLoading) {
     return (
@@ -65,165 +54,18 @@ export function DistrictAppearance() {
   }
 
   return (
-    <div className="p-6 lg:p-8 space-y-6 max-w-[1100px]">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1
-            className="text-2xl sm:text-[28px] font-medium tracking-tight"
-            style={{ fontFamily: "'Playfair Display', Georgia, serif", color: 'var(--editorial-text-primary)' }}
-          >
-            Appearance
-          </h1>
-          <p className="text-sm mt-1" style={{ color: 'var(--editorial-text-muted)' }}>
-            Customize your district's branding
-          </p>
-        </div>
-        <button
-          data-testid="appearance-save-btn"
-          onClick={handleSave}
-          disabled={updateDistrict.isPending}
-          className="flex items-center gap-2 px-4 py-2.5 text-white rounded-lg transition-colors disabled:opacity-50 font-semibold text-sm"
-          style={{ backgroundColor: 'var(--editorial-accent-primary)' }}
-          onMouseEnter={(e) => { if (!updateDistrict.isPending) e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary-hover)'; }}
-          onMouseLeave={(e) => { if (!updateDistrict.isPending) e.currentTarget.style.backgroundColor = 'var(--editorial-accent-primary)'; }}
-        >
-          {updateDistrict.isPending ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            <>
-              <Save className="h-4 w-4" />
-              Save Changes
-            </>
-          )}
-        </button>
-      </div>
-
-      {/* Settings Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Colors */}
-        <div className="rounded-xl p-6" style={{ backgroundColor: 'var(--editorial-surface)', border: '1px solid var(--editorial-border)' }}>
-          <div className="flex items-center gap-3 mb-4">
-            <div className="p-2 rounded-lg" style={{ backgroundColor: 'rgba(184, 92, 56, 0.1)' }}>
-              <Palette className="h-5 w-5" style={{ color: 'var(--editorial-accent-primary)' }} />
-            </div>
-            <h2 className="text-lg font-semibold" style={{ color: 'var(--editorial-text-primary)' }}>Colors</h2>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium mb-2" style={{ color: 'var(--editorial-text-secondary)' }}>
-                Primary Color
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="color"
-                  data-testid="color-primary-picker"
-                  value={primaryColor}
-                  onChange={(e) => setPrimaryColor(e.target.value)}
-                  className="w-12 h-12 rounded-lg cursor-pointer"
-                  style={{ border: '1px solid var(--editorial-border)' }}
-                />
-                <input
-                  type="text"
-                  data-testid="color-primary-input"
-                  value={primaryColor}
-                  onChange={(e) => setPrimaryColor(e.target.value)}
-                  className="flex-1 px-3 py-2 rounded-lg focus:outline-none"
-                  style={{ border: '1px solid var(--editorial-border)', color: 'var(--editorial-text-primary)' }}
-                  placeholder="#0099CC"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium mb-2" style={{ color: 'var(--editorial-text-secondary)' }}>
-                Secondary Color
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="color"
-                  data-testid="color-secondary-picker"
-                  value={secondaryColor}
-                  onChange={(e) => setSecondaryColor(e.target.value)}
-                  className="w-12 h-12 rounded-lg cursor-pointer"
-                  style={{ border: '1px solid var(--editorial-border)' }}
-                />
-                <input
-                  type="text"
-                  data-testid="color-secondary-input"
-                  value={secondaryColor}
-                  onChange={(e) => setSecondaryColor(e.target.value)}
-                  className="flex-1 px-3 py-2 rounded-lg focus:outline-none"
-                  style={{ border: '1px solid var(--editorial-border)', color: 'var(--editorial-text-primary)' }}
-                  placeholder="#FFB800"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Logo */}
-        <div className="rounded-xl p-6" style={{ backgroundColor: 'var(--editorial-surface)', border: '1px solid var(--editorial-border)' }}>
-          <div className="flex items-center gap-3 mb-4">
-            <div className="p-2 rounded-lg" style={{ backgroundColor: 'rgba(74, 111, 165, 0.1)' }}>
-              <ImageIcon className="h-5 w-5" style={{ color: 'var(--editorial-accent-link)' }} />
-            </div>
-            <h2 className="text-lg font-semibold" style={{ color: 'var(--editorial-text-primary)' }}>Logo</h2>
-          </div>
-
-          <LogoUpload
-            currentUrl={logoUrl}
-            onUpload={(url) => setLogoUrl(url)}
-            onRemove={() => setLogoUrl('')}
-            folder="district-logos"
-            label="District Logo"
-            helpText="PNG, JPG, SVG or WebP. Max 5MB."
-          />
-        </div>
-      </div>
-
-      {/* Dashboard Template */}
-      <div className="rounded-xl p-6" style={{ backgroundColor: 'var(--editorial-surface)', border: '1px solid var(--editorial-border)' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'rgba(201, 162, 39, 0.1)' }}>
-            <LayoutTemplate className="h-5 w-5" style={{ color: 'var(--editorial-accent-secondary)' }} />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold" style={{ color: 'var(--editorial-text-primary)' }}>Dashboard Template</h2>
-            <p className="text-sm" style={{ color: 'var(--editorial-text-muted)' }}>
-              Choose how your public dashboard looks
-            </p>
-          </div>
-        </div>
-
-        <TemplateSelector
-          value={dashboardTemplate}
-          onChange={setDashboardTemplate}
-          disabled={updateDistrict.isPending}
-        />
-
-        <div className="mt-6 pt-6" style={{ borderTop: '1px solid var(--editorial-border-light)' }}>
-          <TemplateConfigEditor
-            template={dashboardTemplate}
-            config={dashboardConfig}
-            onChange={setDashboardConfig}
-            disabled={updateDistrict.isPending}
-          />
-        </div>
-      </div>
-
-      {/* Preview */}
-      <AppearancePreview
-        primaryColor={primaryColor}
-        secondaryColor={secondaryColor}
-        logoUrl={logoUrl}
-        districtName={district?.name || 'District Name'}
-        tagline={district?.tagline}
-      />
-    </div>
+    <AppearanceProvider
+      value={{
+        state,
+        dispatch,
+        districtName: district?.name || 'District Name',
+        districtTagline: district?.tagline,
+        districtSlug: district?.slug || slug || 'district',
+        save,
+        isSaving: updateDistrict.isPending,
+      }}
+    >
+      <AppearanceEditor />
+    </AppearanceProvider>
   );
 }

--- a/src/pages/client/admin/__tests__/DistrictAppearance.test.tsx
+++ b/src/pages/client/admin/__tests__/DistrictAppearance.test.tsx
@@ -6,6 +6,23 @@ import { SubdomainProvider } from '../../../../contexts/SubdomainContext';
 import { DistrictAppearance } from '../DistrictAppearance';
 import type { District } from '../../../../lib/types';
 
+// Mock framer-motion to avoid animation timing issues in tests
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  return {
+    motion: new Proxy({}, {
+      get: (_target: unknown, prop: string) => {
+        return React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+          return React.createElement(prop as string, { ...rest, ref });
+        });
+      },
+    }),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
 // Mock the SubdomainContext
 vi.mock('../../../../contexts/SubdomainContext', async () => {
   const actual = await vi.importActual('../../../../contexts/SubdomainContext');
@@ -68,10 +85,10 @@ vi.mock('../../../../hooks/useUpload', () => ({
   })),
 }));
 
-// Mock TemplateRegistry
-vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
-  getAllTemplates: () => [
-    {
+// Mock TemplateRegistry — include getMergedConfig used by new components
+vi.mock('../../../../components/public/templates/TemplateRegistry', () => {
+  const templates: Record<string, unknown> = {
+    hierarchical: {
       id: 'hierarchical',
       name: 'Hierarchical',
       description: 'Traditional layout',
@@ -83,7 +100,7 @@ vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
         cardVariant: 'default',
       },
     },
-    {
+    'metrics-grid': {
       id: 'metrics-grid',
       name: 'Metrics Grid',
       description: 'Flat grid',
@@ -95,7 +112,7 @@ vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
         cardVariant: 'compact',
       },
     },
-    {
+    'launch-traction': {
       id: 'launch-traction',
       name: 'Launch Traction',
       description: 'Animated dashboard',
@@ -107,49 +124,18 @@ vi.mock('../../../../components/public/templates/TemplateRegistry', () => ({
         cardVariant: 'rich',
       },
     },
-  ],
-  getTemplateInfo: (templateId: string) => {
-    const templates: Record<string, unknown> = {
-      hierarchical: {
-        id: 'hierarchical',
-        name: 'Hierarchical',
-        description: 'Traditional layout',
-        defaultConfig: {
-          showSidebar: true,
-          showNarrativeHero: true,
-          gridColumns: 3,
-          enableAnimations: false,
-          cardVariant: 'default',
-        },
-      },
-      'metrics-grid': {
-        id: 'metrics-grid',
-        name: 'Metrics Grid',
-        description: 'Flat grid',
-        defaultConfig: {
-          showSidebar: true,
-          showNarrativeHero: true,
-          gridColumns: 3,
-          enableAnimations: true,
-          cardVariant: 'compact',
-        },
-      },
-      'launch-traction': {
-        id: 'launch-traction',
-        name: 'Launch Traction',
-        description: 'Animated dashboard',
-        defaultConfig: {
-          showSidebar: false,
-          showNarrativeHero: false,
-          gridColumns: 4,
-          enableAnimations: true,
-          cardVariant: 'rich',
-        },
-      },
-    };
-    return templates[templateId] || templates.hierarchical;
-  },
-}));
+  };
+
+  return {
+    getAllTemplates: () => Object.values(templates),
+    getTemplateInfo: (templateId: string) => templates[templateId] || templates.hierarchical,
+    getMergedConfig: (templateId: string, customConfig?: Record<string, unknown>) => {
+      const info = templates[templateId] || templates.hierarchical;
+      const defaults = (info as { defaultConfig: Record<string, unknown> }).defaultConfig;
+      return { ...defaults, ...customConfig };
+    },
+  };
+});
 
 // Import after mocking
 import { useDistrict, useUpdateDistrict } from '../../../../hooks/useDistricts';
@@ -174,12 +160,17 @@ const renderComponent = () => {
   );
 };
 
+/** Expand a collapsed config section by clicking its header */
+function expandSection(sectionTitle: string) {
+  const button = screen.getByText(sectionTitle).closest('button');
+  if (button) fireEvent.click(button);
+}
+
 describe('DistrictAppearance', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMutateAsync.mockResolvedValue(mockDistrict);
 
-    // Reset mock implementations to default
     vi.mocked(useDistrict).mockReturnValue({
       data: mockDistrict,
       isLoading: false,
@@ -203,7 +194,6 @@ describe('DistrictAppearance', () => {
 
       renderComponent();
 
-      // Should show loading skeleton (animate-pulse class)
       const skeleton = document.querySelector('.animate-pulse');
       expect(skeleton).toBeInTheDocument();
     });
@@ -241,7 +231,7 @@ describe('DistrictAppearance', () => {
     it('displays Colors section', () => {
       renderComponent();
 
-      expect(screen.getByText('Colors')).toBeInTheDocument();
+      expect(screen.getByText('Brand Colors')).toBeInTheDocument();
       expect(screen.getByText('Primary Color')).toBeInTheDocument();
       expect(screen.getByText('Secondary Color')).toBeInTheDocument();
     });
@@ -261,39 +251,30 @@ describe('DistrictAppearance', () => {
   });
 
   describe('Preview section', () => {
-    it('shows preview section', () => {
+    it('shows live preview label', () => {
       renderComponent();
 
-      expect(screen.getByTestId('appearance-preview')).toBeInTheDocument();
-      expect(screen.getByText('Preview')).toBeInTheDocument();
+      expect(screen.getByText('Live Preview')).toBeInTheDocument();
     });
 
-    it('shows district name in preview header', () => {
+    it('shows district name in preview', () => {
       renderComponent();
 
-      // District name appears in the preview header
-      const preview = screen.getByTestId('appearance-preview');
-      expect(preview).toHaveTextContent('Test District');
+      const matches = screen.getAllByText('Test District');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('shows Homepage and Dashboard tabs', () => {
+    it('shows Desktop and Mobile device toggles', () => {
       renderComponent();
 
-      expect(screen.getByText('Homepage')).toBeInTheDocument();
-      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      expect(screen.getByTitle('Desktop preview')).toBeInTheDocument();
+      expect(screen.getByTitle('Mobile preview')).toBeInTheDocument();
     });
 
     it('shows browser chrome with district URL', () => {
       renderComponent();
 
-      // Preview shows a mock browser URL
-      expect(screen.getByText(/testdistrict\.stratadash\.com/i)).toBeInTheDocument();
-    });
-
-    it('shows helper text about real-time updates', () => {
-      renderComponent();
-
-      expect(screen.getByText(/Changes are reflected in real-time/i)).toBeInTheDocument();
+      expect(screen.getByText(/test-district\.stratadash\.com/i)).toBeInTheDocument();
     });
 
     it('shows logo in preview when logoUrl is set', () => {
@@ -310,7 +291,6 @@ describe('DistrictAppearance', () => {
 
       renderComponent();
 
-      // Find any image with the logo URL in the preview
       const logoImages = screen.getAllByRole('img');
       const logoImage = logoImages.find(img => img.getAttribute('src') === 'https://example.com/logo.png');
       expect(logoImage).toBeInTheDocument();
@@ -336,59 +316,63 @@ describe('DistrictAppearance', () => {
       expect(secondaryInput).toHaveValue('#00FF00');
     });
 
-    it('preview updates when color changes', () => {
+    it('shows unsaved indicator when color changes', () => {
       renderComponent();
 
       const primaryInput = screen.getByTestId('color-primary-input');
       fireEvent.change(primaryInput, { target: { value: '#FF0000' } });
 
-      // The preview contains elements styled with the primary color
-      // Check that the preview container is still visible (real-time update)
-      const preview = screen.getByTestId('appearance-preview');
-      expect(preview).toBeInTheDocument();
+      expect(screen.getByText('Unsaved')).toBeInTheDocument();
     });
   });
 
   describe('Template selection', () => {
-    it('can select a different template', () => {
+    it('can select a different template', async () => {
       renderComponent();
 
       const metricsGridOption = screen.getByTestId('template-option-metrics-grid');
       fireEvent.click(metricsGridOption);
 
-      expect(metricsGridOption).toHaveClass('border-amber-500');
+      await waitFor(() => {
+        expect(screen.getByTestId('template-option-metrics-grid')).toHaveClass('border-amber-500');
+      });
     });
   });
 
   describe('Template config', () => {
     it('can toggle sidebar visibility', () => {
       renderComponent();
+      expandSection('Layout Options');
 
       const sidebarToggle = screen.getByTestId('config-show-sidebar') as HTMLInputElement;
       const initialChecked = sidebarToggle.checked;
-
       fireEvent.click(sidebarToggle);
 
-      // State should have changed
       expect(sidebarToggle.checked).toBe(!initialChecked);
     });
 
-    it('can change grid columns', () => {
+    it('can change grid columns', async () => {
       renderComponent();
+      expandSection('Grid Density');
 
       const grid4Button = screen.getByTestId('config-grid-4');
       fireEvent.click(grid4Button);
 
-      expect(grid4Button).toHaveClass('bg-amber-500');
+      await waitFor(() => {
+        expect(screen.getByTestId('config-grid-4')).toHaveStyle({ backgroundColor: 'var(--editorial-accent-primary)' });
+      });
     });
 
-    it('can change card style', () => {
+    it('can change card style', async () => {
       renderComponent();
+      expandSection('Card Style');
 
       const richButton = screen.getByTestId('config-card-rich');
       fireEvent.click(richButton);
 
-      expect(richButton).toHaveClass('bg-amber-500');
+      await waitFor(() => {
+        expect(screen.getByTestId('config-card-rich')).toHaveStyle({ backgroundColor: 'var(--editorial-accent-primary)' });
+      });
     });
   });
 
@@ -403,14 +387,12 @@ describe('DistrictAppearance', () => {
     it('calls updateDistrict with all form values on save', async () => {
       renderComponent();
 
-      // Make some changes
       const primaryInput = screen.getByTestId('color-primary-input');
       fireEvent.change(primaryInput, { target: { value: '#FF0000' } });
 
       const metricsGridOption = screen.getByTestId('template-option-metrics-grid');
       fireEvent.click(metricsGridOption);
 
-      // Click save
       const saveButton = screen.getByTestId('appearance-save-btn');
       fireEvent.click(saveButton);
 
@@ -473,6 +455,7 @@ describe('DistrictAppearance', () => {
       } as unknown as ReturnType<typeof useUpdateDistrict>);
 
       renderComponent();
+      expandSection('Layout Options');
 
       expect(screen.getByTestId('config-show-sidebar')).toBeDisabled();
       expect(screen.getByTestId('config-show-hero')).toBeDisabled();
@@ -512,7 +495,7 @@ describe('DistrictAppearance', () => {
         dashboard_config: {
           showSidebar: false,
           showNarrativeHero: true,
-          gridColumns: 4,
+          gridColumns: 4 as const,
           enableAnimations: true,
           cardVariant: 'compact' as const,
         },
@@ -525,10 +508,11 @@ describe('DistrictAppearance', () => {
       } as ReturnType<typeof useDistrict>);
 
       renderComponent();
+      expandSection('Grid Density');
+      expandSection('Card Style');
 
-      // Check that config values are reflected
-      expect(screen.getByTestId('config-grid-4')).toHaveClass('bg-amber-500');
-      expect(screen.getByTestId('config-card-compact')).toHaveClass('bg-amber-500');
+      expect(screen.getByTestId('config-grid-4')).toHaveStyle({ backgroundColor: 'var(--editorial-accent-primary)' });
+      expect(screen.getByTestId('config-card-compact')).toHaveStyle({ backgroundColor: 'var(--editorial-accent-primary)' });
     });
   });
 });


### PR DESCRIPTION
## Summary
- **WYSIWYG Appearance Editor**: Replace the old appearance settings page with a split-view editor featuring a live preview panel and config panel for brand colors, layout options, card styles, and grid density
- **Fix dead Westside logo URL**: Clear the broken external logo URL from seed data that was causing 404 console errors
- **Image fallback in PreviewHeader**: Add `onError` handler so broken logo URLs gracefully fall back to initials display

## Test plan
- [ ] Verify appearance editor loads with split-view (config panel left, preview right)
- [ ] Change brand colors in config panel → preview updates live
- [ ] Set a broken logo URL → preview shows initials instead of broken image
- [ ] Run `npm run db:seed` after seed change → no more 404 console errors for Westside logo
- [ ] All 808 tests pass (`npm run test:run`)
- [ ] Type check clean (`npm run type-check`)
- [ ] Lint passes with no errors (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Appearance editor with live preview showing real-time customization changes
  * Multiple dashboard templates to choose from
  * Brand color customization with preset palette options
  * Logo upload and management
  * Layout configuration options (sidebar visibility, hero sections, animations)
  * Grid density and card style selection
  * Mobile device preview mode for responsive testing

* **Bug Fixes**
  * Improved logo image error handling with fallback display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->