### PR TITLE
feat: promote marketing, pricing & onboarding to root routes

### DIFF
--- a/src/components/v2/layout/V2MarketingLayout.tsx
+++ b/src/components/v2/layout/V2MarketingLayout.tsx
@@ -5,7 +5,7 @@ export function V2MarketingLayout() {
     <div className="min-h-screen bg-white flex flex-col">
       <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
-          <Link to="/v2" className="text-xl font-bold">
+          <Link to="/" className="text-xl font-bold">
             <span className="text-gray-900">Strata</span>
             <span className="text-blue-500">Dash</span>
           </Link>
@@ -14,7 +14,7 @@ export function V2MarketingLayout() {
             <a href="#features" className="hover:text-gray-900 transition-colors">
               Features
             </a>
-            <Link to="/v2/pricing" className="hover:text-gray-900 transition-colors">
+            <Link to="/pricing" className="hover:text-gray-900 transition-colors">
               Pricing
             </Link>
             <a href="#examples" className="hover:text-gray-900 transition-colors">
@@ -30,7 +30,7 @@ export function V2MarketingLayout() {
               Log In
             </Link>
             <Link
-              to="/signup?redirect=/v2/onboard"
+              to="/signup?redirect=/onboard"
               className="text-sm font-medium text-white bg-blue-500 rounded-lg px-4 py-2 hover:bg-blue-600 transition-colors"
             >
               Start Free
@@ -47,7 +47,7 @@ export function V2MarketingLayout() {
         <div className="max-w-7xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-500">
           <p>&copy; {new Date().getFullYear()} StrataDash. All rights reserved.</p>
           <div className="flex items-center gap-6">
-            <Link to="/v2/pricing" className="hover:text-gray-700 transition-colors">
+            <Link to="/pricing" className="hover:text-gray-700 transition-colors">
               Pricing
             </Link>
             <a href="mailto:support@stratadash.org" className="hover:text-gray-700 transition-colors">

--- a/src/pages/v2/marketing/V2Landing.tsx
+++ b/src/pages/v2/marketing/V2Landing.tsx
@@ -38,13 +38,13 @@ export function V2Landing() {
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <Link
-              to="/signup?redirect=/v2/onboard"
+              to="/signup?redirect=/onboard"
               className="w-full sm:w-auto text-center font-medium text-white bg-blue-500 rounded-lg px-8 py-3 hover:bg-blue-600 transition-colors"
             >
               Get Started Free
             </Link>
             <Link
-              to="/v2/pricing"
+              to="/pricing"
               className="w-full sm:w-auto text-center font-medium text-gray-700 border border-gray-300 rounded-lg px-8 py-3 hover:bg-gray-50 transition-colors"
             >
               View Pricing

--- a/src/pages/v2/marketing/V2Pricing.tsx
+++ b/src/pages/v2/marketing/V2Pricing.tsx
@@ -24,7 +24,7 @@ const tiers: Tier[] = [
       'Community support',
     ],
     cta: 'Get Started',
-    ctaLink: '/signup?redirect=/v2/onboard',
+    ctaLink: '/signup?redirect=/onboard',
   },
   {
     name: 'Pro',
@@ -39,7 +39,7 @@ const tiers: Tier[] = [
       'Excel import',
     ],
     cta: 'Start Free Trial',
-    ctaLink: '/signup?redirect=/v2/onboard',
+    ctaLink: '/signup?redirect=/onboard',
     highlighted: true,
   },
   {

--- a/src/pages/v2/marketing/__tests__/V2Landing.test.tsx
+++ b/src/pages/v2/marketing/__tests__/V2Landing.test.tsx
@@ -20,7 +20,7 @@ describe('V2Landing', () => {
 
     const ctaLink = screen.getByText('Get Started Free');
     expect(ctaLink).toBeInTheDocument();
-    expect(ctaLink.closest('a')).toHaveAttribute('href', '/signup?redirect=/v2/onboard');
+    expect(ctaLink.closest('a')).toHaveAttribute('href', '/signup?redirect=/onboard');
   });
 
   it('renders View Pricing link', () => {
@@ -28,7 +28,7 @@ describe('V2Landing', () => {
 
     const pricingLink = screen.getByText('View Pricing');
     expect(pricingLink).toBeInTheDocument();
-    expect(pricingLink.closest('a')).toHaveAttribute('href', '/v2/pricing');
+    expect(pricingLink.closest('a')).toHaveAttribute('href', '/pricing');
   });
 
   it('renders feature sections', () => {

--- a/src/pages/v2/marketing/__tests__/V2Pricing.test.tsx
+++ b/src/pages/v2/marketing/__tests__/V2Pricing.test.tsx
@@ -65,6 +65,6 @@ describe('V2Pricing', () => {
     render(<V2Pricing />);
 
     const getStartedLink = screen.getByText('Get Started');
-    expect(getStartedLink.closest('a')).toHaveAttribute('href', '/signup?redirect=/v2/onboard');
+    expect(getStartedLink.closest('a')).toHaveAttribute('href', '/signup?redirect=/onboard');
   });
 });

--- a/src/routers/RootRouter.tsx
+++ b/src/routers/RootRouter.tsx
@@ -1,6 +1,5 @@
 import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { MarketingLanding } from '../pages/marketing/Landing';
 import { Login } from '../pages/Login';
 import { Signup } from '../pages/Signup';
 import { ForgotPassword } from '../pages/ForgotPassword';
@@ -41,17 +40,47 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+const SuspensePage = (
+  <div className="flex-1 flex items-center justify-center py-20">
+    <div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" />
+  </div>
+);
+
+const SuspenseFullPage = (
+  <div className="min-h-screen flex items-center justify-center">
+    <div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" />
+  </div>
+);
+
 /**
  * Router for the root domain (stratadash.org)
- * - Marketing landing page at /
- * - User dashboard at /dashboard (requires authentication)
- * - V2 marketing pages at /v2
+ * - Marketing pages at / and /pricing
+ * - Onboarding at /onboard (requires auth)
+ * - User dashboard at /dashboard (requires auth)
  */
 export function RootRouter() {
   return (
     <Routes>
-      {/* Marketing landing page - always visible */}
-      <Route path="/" element={<MarketingLanding />} />
+      {/* Marketing pages with V2 layout */}
+      <Route path="/" element={
+        <ErrorBoundary>
+          <Suspense fallback={SuspenseFullPage}>
+            <V2MarketingLayout />
+          </Suspense>
+        </ErrorBoundary>
+      }>
+        <Route index element={<Suspense fallback={SuspensePage}><V2Landing /></Suspense>} />
+        <Route path="pricing" element={<Suspense fallback={SuspensePage}><V2Pricing /></Suspense>} />
+      </Route>
+
+      {/* Onboarding wizard (requires auth, no marketing layout) */}
+      <Route path="/onboard/*" element={
+        <RequireAuth>
+          <Suspense fallback={SuspenseFullPage}>
+            <V2OnboardingWizard />
+          </Suspense>
+        </RequireAuth>
+      } />
 
       {/* Dashboard - requires authentication */}
       <Route
@@ -106,18 +135,10 @@ export function RootRouter() {
         }
       />
 
-      {/* V2 Routes */}
-      <Route path="/v2" element={
-        <ErrorBoundary>
-          <Suspense fallback={<div className="min-h-screen flex items-center justify-center"><div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" /></div>}>
-            <V2MarketingLayout />
-          </Suspense>
-        </ErrorBoundary>
-      }>
-        <Route index element={<Suspense fallback={<div className="flex-1 flex items-center justify-center py-20"><div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" /></div>}><V2Landing /></Suspense>} />
-        <Route path="pricing" element={<Suspense fallback={<div className="flex-1 flex items-center justify-center py-20"><div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" /></div>}><V2Pricing /></Suspense>} />
-        <Route path="onboard/*" element={<RequireAuth><Suspense fallback={<div className="flex-1 flex items-center justify-center py-20"><div className="animate-spin w-8 h-8 border-4 border-gray-300 border-t-gray-900 rounded-full" /></div>}><V2OnboardingWizard /></Suspense></RequireAuth>} />
-      </Route>
+      {/* Legacy /v2 redirects */}
+      <Route path="/v2" element={<Navigate to="/" replace />} />
+      <Route path="/v2/pricing" element={<Navigate to="/pricing" replace />} />
+      <Route path="/v2/onboard/*" element={<Navigate to="/onboard" replace />} />
 
       {/* Catch-all */}
       <Route path="*" element={<Navigate to="/" replace />} />


### PR DESCRIPTION
## Summary
- `/` now shows V2 landing page (replaces old MarketingLanding)
- `/pricing` shows pricing tiers with signup CTAs
- `/onboard` starts the onboarding wizard (auth required)
- `/v2/*` redirects to new paths for backwards compatibility
- All internal links updated across 6 files

## Test plan
- [ ] Visit `stratadash.org` — shows V2 landing with "Get Started Free" and "View Pricing" links
- [ ] Click "View Pricing" — navigates to `/pricing`
- [ ] Click "Get Started Free" — goes to signup, then redirects to `/onboard`
- [ ] Visit `/v2/pricing` — redirects to `/pricing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)