### PR TITLE
fix(routing): correct root-domain branch and normalize leading slash in buildDistrictPath helpers

### DIFF
--- a/src/lib/__tests__/subdomain.test.ts
+++ b/src/lib/__tests__/subdomain.test.ts
@@ -510,8 +510,12 @@ describe('buildDistrictPath', () => {
     expect(buildDistrictPath('/objective/123', 'westside', false)).toBe('/district/westside/objective/123');
   });
 
-  it('handles path without leading slash for subdomain', () => {
-    expect(buildDistrictPath('objective/123', 'westside', true)).toBe('objective/123');
+  it('normalizes path without leading slash for subdomain', () => {
+    expect(buildDistrictPath('objective/123', 'westside', true)).toBe('/objective/123');
+  });
+
+  it('normalizes path without leading slash for root domain', () => {
+    expect(buildDistrictPath('objective/123', 'westside', false)).toBe('/district/westside/objective/123');
   });
 
   it('handles root path for subdomain', () => {
@@ -539,6 +543,16 @@ describe('buildDistrictPathWithQueryParam — root-domain branch', () => {
     // a query-param subdomain host — so the query-param gets appended even
     // when isSubdomain=true.
     expect(buildDistrictPathWithQueryParam('/goals', 'westside', true))
+      .toBe('/goals?subdomain=westside');
+  });
+
+  it('normalizes path without leading slash on root domain', () => {
+    expect(buildDistrictPathWithQueryParam('goals/abc-123', 'westside', false))
+      .toBe('/district/westside/goals/abc-123');
+  });
+
+  it('normalizes path without leading slash on subdomain (jsdom query-param form)', () => {
+    expect(buildDistrictPathWithQueryParam('goals', 'westside', true))
       .toBe('/goals?subdomain=westside');
   });
 });

--- a/src/lib/__tests__/subdomain.test.ts
+++ b/src/lib/__tests__/subdomain.test.ts
@@ -6,6 +6,7 @@ import {
   getSubdomainUrl,
   buildSubdomainUrlWithPath,
   buildDistrictPath,
+  buildDistrictPathWithQueryParam,
 } from '../subdomain';
 
 /**
@@ -506,7 +507,7 @@ describe('buildDistrictPath', () => {
   });
 
   it('prepends slug when on root domain', () => {
-    expect(buildDistrictPath('/objective/123', 'westside', false)).toBe('/westside/objective/123');
+    expect(buildDistrictPath('/objective/123', 'westside', false)).toBe('/district/westside/objective/123');
   });
 
   it('handles path without leading slash for subdomain', () => {
@@ -518,6 +519,37 @@ describe('buildDistrictPath', () => {
   });
 
   it('handles root path for path-based routing', () => {
-    expect(buildDistrictPath('/', 'westside', false)).toBe('/westside/');
+    expect(buildDistrictPath('/', 'westside', false)).toBe('/district/westside/');
+  });
+});
+
+describe('buildDistrictPathWithQueryParam — root-domain branch', () => {
+  it('returns /district/<slug><basePath> when isSubdomain=false', () => {
+    expect(buildDistrictPathWithQueryParam('/goals', 'westside', false))
+      .toBe('/district/westside/goals');
+  });
+
+  it('returns /district/<slug><basePath> when isSubdomain=false and basePath has deep segments', () => {
+    expect(buildDistrictPathWithQueryParam('/goals/abc-123', 'westside', false))
+      .toBe('/district/westside/goals/abc-123');
+  });
+
+  it('returns query-param form on a subdomain in jsdom', () => {
+    // In jsdom, window.location.hostname is 'localhost' which is treated as
+    // a query-param subdomain host — so the query-param gets appended even
+    // when isSubdomain=true.
+    expect(buildDistrictPathWithQueryParam('/goals', 'westside', true))
+      .toBe('/goals?subdomain=westside');
+  });
+});
+
+describe('buildDistrictPath — root-domain branch', () => {
+  it('returns /district/<slug><basePath> when isSubdomain=false', () => {
+    expect(buildDistrictPath('/goals', 'westside', false))
+      .toBe('/district/westside/goals');
+  });
+
+  it('returns basePath unchanged when isSubdomain=true', () => {
+    expect(buildDistrictPath('/goals', 'westside', true)).toBe('/goals');
   });
 });

--- a/src/lib/subdomain.ts
+++ b/src/lib/subdomain.ts
@@ -202,8 +202,8 @@ export function buildDistrictPath(basePath: string, slug: string, isSubdomain: b
   if (isSubdomain) {
     return basePath;
   }
-  // On root domain, include slug in path
-  return `/${slug}${basePath}`;
+  // On root domain, include slug in path under /district/
+  return `/district/${slug}${basePath}`;
 }
 
 /**
@@ -229,8 +229,8 @@ export function buildDistrictPathWithQueryParam(
     // Real subdomain (westside.stratadash.org) - no query param needed
     return basePath;
   }
-  // On root domain, include slug in path
-  return `/${slug}${basePath}`;
+  // On root domain, include slug in path under /district/
+  return `/district/${slug}${basePath}`;
 }
 
 /**

--- a/src/lib/subdomain.ts
+++ b/src/lib/subdomain.ts
@@ -23,6 +23,10 @@ const ROOT_DOMAINS = [
 
 const ADMIN_SUBDOMAINS = ['admin'];
 
+function ensureLeadingSlash(path: string): string {
+  return path && !path.startsWith('/') ? `/${path}` : path;
+}
+
 /**
  * Get subdomain information from the current hostname
  */
@@ -198,12 +202,11 @@ export function isQueryParamSubdomain(): boolean {
  * For components using React Router <Link>, use the useDistrictLink hook instead.
  */
 export function buildDistrictPath(basePath: string, slug: string, isSubdomain: boolean): string {
-  // On subdomain, paths don't need slug prefix
+  const normalizedPath = ensureLeadingSlash(basePath);
   if (isSubdomain) {
-    return basePath;
+    return normalizedPath;
   }
-  // On root domain, include slug in path under /district/
-  return `/district/${slug}${basePath}`;
+  return `/district/${slug}${normalizedPath}`;
 }
 
 /**
@@ -220,17 +223,16 @@ export function buildDistrictPathWithQueryParam(
   slug: string,
   isSubdomain: boolean
 ): string {
-  // On subdomain routing
+  const normalizedPath = ensureLeadingSlash(basePath);
   if (isSubdomain) {
-    // If using query param simulation (localhost/Vercel preview), preserve it
+    // Localhost/Vercel preview simulate subdomains via ?subdomain= since
+    // real subdomain DNS isn't available — preserve the query param.
     if (isQueryParamSubdomain()) {
-      return `${basePath}?subdomain=${slug}`;
+      return `${normalizedPath}?subdomain=${slug}`;
     }
-    // Real subdomain (westside.stratadash.org) - no query param needed
-    return basePath;
+    return normalizedPath;
   }
-  // On root domain, include slug in path under /district/
-  return `/district/${slug}${basePath}`;
+  return `/district/${slug}${normalizedPath}`;
 }
 
 /**
@@ -243,8 +245,7 @@ export function buildDistrictPathWithQueryParam(
  *   - production: https://admin.stratadash.org/districts
  */
 export function buildSubdomainUrlWithPath(type: SubdomainType, path: string = '', slug?: string): string {
-  // Ensure path starts with /
-  const normalizedPath = path && !path.startsWith('/') ? `/${path}` : path;
+  const normalizedPath = ensureLeadingSlash(path);
 
   if (typeof window === 'undefined') {
     if (type === 'admin') return `https://admin.stratadash.org${normalizedPath}`;


### PR DESCRIPTION
## Summary

Two small, focused fixes to the path-builder helpers in [src/lib/subdomain.ts](src/lib/subdomain.ts). Touches only that file and its tests (+64 / -17). Replaces [#159](https://github.com/ptoney514/strategic-plan-app/pull/159), which accidentally included ~33 unrelated feature commits.

## Commits

**1. `fix(routing): correct root-domain branch in buildDistrictPath helpers`**
Both `buildDistrictPath` and `buildDistrictPathWithQueryParam` returned `/<slug><basePath>` for path-based access, but the canonical route tree is `/district/<slug>/...` — the `/<slug>/...` form points at a nonexistent route. Returning the correct prefix unblocks path-based navigation.

**2. `fix(routing): normalize leading slash in buildDistrictPath helpers`**
Both helpers previously returned `basePath` unchanged, so callers passing un-normalized input (e.g. `'objective/123'`) got back a relative path — which can silently break navigation on a subdomain. `buildSubdomainUrlWithPath` already had this normalization — ported the same pattern via a shared file-private `ensureLeadingSlash()` helper so all three sibling helpers share one source of truth. Also tightened comments (removed WHAT-narrating ones that duplicated JSDoc).

## Test plan
- [x] `npx vitest run src/lib/__tests__/subdomain.test.ts` → 65/65 passing
- [x] End-to-end Playwright verification of helper behavior on `westside.lvh.me:5174` (un-normalized input returns `/objective/123` on subdomain, `/district/westside/objective/123` on root)
- [ ] CI lint + typecheck + unit tests green
- [ ] Vercel preview loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)