### PR TITLE
feat(db): v4 public dashboard schema reconcile

### DIFF
--- a/_api/lib/schema/goals.ts
+++ b/_api/lib/schema/goals.ts
@@ -6,6 +6,7 @@ import {
   text,
   integer,
   decimal,
+  jsonb,
   index,
   foreignKey,
 } from "drizzle-orm/pg-core";
@@ -39,6 +40,18 @@ export const goals = pgTable(
     // Metadata fields
     ownerName: varchar("owner_name", { length: 255 }),
     priority: varchar("priority", { length: 20 }),
+
+    // v4 public dashboard fields (design.md §6.2, §5.13)
+    // narrative: expanded-row callout paragraph (any level)
+    // pullQuoteText/Attribution: per-objective pull quote (level 0)
+    // highlightStats: 3-up stat callouts under the left narrative column (level 0)
+    //   shape: [{ label: string, value: string | number, unit?: string }, ...]
+    // signatureWidgetId: FK to the widget to render as the §5.7 signature metric card (level 0)
+    narrative: text("narrative"),
+    pullQuoteText: text("pull_quote_text"),
+    pullQuoteAttribution: varchar("pull_quote_attribution", { length: 255 }),
+    highlightStats: jsonb("highlight_stats"),
+    signatureWidgetId: uuid("signature_widget_id"),
 
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at")

--- a/drizzle/migrations/0009_v4_dashboard_schema.sql
+++ b/drizzle/migrations/0009_v4_dashboard_schema.sql
@@ -1,0 +1,50 @@
+-- v4 public dashboard schema reconcile (design.md §5.3, §5.7, §5.8, §5.13, §6.2)
+-- Adds per-goal narrative, per-objective pull quote + highlight stats + signature-metric
+-- pointer, and locks goals.status to the design's allowed set via a CHECK constraint.
+-- Statement-breakpoint'd so drizzle-kit migrate can run each piece independently.
+
+-- 1. Per-goal narrative text (expanded Pattern A row green-tinted callout — any level)
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "narrative" text;--> statement-breakpoint
+
+-- 2. Per-objective pull quote (design.md §5.13 — intended for level-0 rows)
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "pull_quote_text" text;--> statement-breakpoint
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "pull_quote_attribution" varchar(255);--> statement-breakpoint
+
+-- 3. 3-up stat callouts under the left narrative column (design.md §6.2 "47 · 124 · 4.1/5")
+--    Shape: jsonb array of { label: text, value: text|number, unit?: text }.
+--    Kept on the goal row so an objective fetch returns it in one round trip.
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "highlight_stats" jsonb;--> statement-breakpoint
+
+-- 4. Signature metric pointer (design.md §5.7 right-column hero card).
+--    FK to widgets so we render an existing widget as the signature card. ON DELETE SET NULL
+--    so deleting the underlying widget doesn't cascade-delete the goal.
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "signature_widget_id" uuid;--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'goals_signature_widget_id_widgets_id_fk'
+  ) THEN
+    ALTER TABLE "goals"
+      ADD CONSTRAINT "goals_signature_widget_id_widgets_id_fk"
+      FOREIGN KEY ("signature_widget_id") REFERENCES "public"."widgets"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "goals_signature_widget_id_idx" ON "goals" USING btree ("signature_widget_id");--> statement-breakpoint
+
+-- 5. Lock goals.status to the design.md §5.3 allowed set.
+--    First, re-map legacy values so the CHECK constraint can be applied without NOT VALID.
+--      completed → complete   (design uses "complete"; see §5.3 chip table)
+--      on_hold   → in_progress (closest design-set analog for paused work)
+--    Any other stray values (historical free-form text) are coerced to not_started as a safety net.
+UPDATE "goals" SET "status" = 'complete' WHERE "status" = 'completed';--> statement-breakpoint
+UPDATE "goals" SET "status" = 'in_progress' WHERE "status" = 'on_hold';--> statement-breakpoint
+UPDATE "goals" SET "status" = 'not_started'
+  WHERE "status" IS NULL
+     OR "status" NOT IN ('on_track','in_progress','off_track','complete','not_started');--> statement-breakpoint
+
+-- Drop any prior incarnation of this constraint so re-runs don't trip.
+ALTER TABLE "goals" DROP CONSTRAINT IF EXISTS "goals_status_check";--> statement-breakpoint
+ALTER TABLE "goals"
+  ADD CONSTRAINT "goals_status_check"
+  CHECK ("status" IN ('on_track','in_progress','off_track','complete','not_started'));

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775425701000,
       "tag": "0008_verification_updated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776672000000,
+      "tag": "0009_v4_dashboard_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,35 +7,21 @@ const nextConfig: NextConfig = {
     root: path.resolve(__dirname),
     resolveAlias: {
       '@api': path.resolve(__dirname, '_api'),
-      // Map .js imports within api/lib/ to their .ts counterparts
-      // (Turbopack doesn't support extensionAlias, so we map explicitly)
-      [path.resolve(__dirname, 'api/lib/auth.js')]: path.resolve(__dirname, 'api/lib/auth.ts'),
-      [path.resolve(__dirname, 'api/lib/db.js')]: path.resolve(__dirname, 'api/lib/db.ts'),
-      [path.resolve(__dirname, 'api/lib/response.js')]: path.resolve(__dirname, 'api/lib/response.ts'),
-      [path.resolve(__dirname, 'api/lib/rateLimit.js')]: path.resolve(__dirname, 'api/lib/rateLimit.ts'),
-      [path.resolve(__dirname, 'api/lib/sentry.js')]: path.resolve(__dirname, 'api/lib/sentry.ts'),
-      [path.resolve(__dirname, 'api/lib/url.js')]: path.resolve(__dirname, 'api/lib/url.ts'),
-      [path.resolve(__dirname, 'api/lib/email.js')]: path.resolve(__dirname, 'api/lib/email.ts'),
-      [path.resolve(__dirname, 'api/lib/email-templates.js')]: path.resolve(__dirname, 'api/lib/email-templates.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/index.js')]: path.resolve(__dirname, 'api/lib/schema/index.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/auth.js')]: path.resolve(__dirname, 'api/lib/schema/auth.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/contact.js')]: path.resolve(__dirname, 'api/lib/schema/contact.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/goals.js')]: path.resolve(__dirname, 'api/lib/schema/goals.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/imports.js')]: path.resolve(__dirname, 'api/lib/schema/imports.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/organizations.js')]: path.resolve(__dirname, 'api/lib/schema/organizations.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/plans.js')]: path.resolve(__dirname, 'api/lib/schema/plans.ts'),
-      [path.resolve(__dirname, 'api/lib/schema/widgets.js')]: path.resolve(__dirname, 'api/lib/schema/widgets.ts'),
-      [path.resolve(__dirname, 'api/lib/middleware/auth.js')]: path.resolve(__dirname, 'api/lib/middleware/auth.ts'),
-      [path.resolve(__dirname, 'api/lib/middleware/index.js')]: path.resolve(__dirname, 'api/lib/middleware/index.ts'),
-      [path.resolve(__dirname, 'api/lib/middleware/roles.js')]: path.resolve(__dirname, 'api/lib/middleware/roles.ts'),
-      [path.resolve(__dirname, 'api/lib/helpers/org-lookup.js')]: path.resolve(__dirname, 'api/lib/helpers/org-lookup.ts'),
-      [path.resolve(__dirname, 'api/lib/helpers/number.js')]: path.resolve(__dirname, 'api/lib/helpers/number.ts'),
     },
+    resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
   },
-  experimental: {
-    extensionAlias: {
+  // Webpack parity: let ESM-style `.js` imports in _api/ resolve to their `.ts`
+  // sources. Required by Better Auth (ESM-only) + Drizzle schema files that
+  // import each other via `./goals.js` etc. Turbopack handles this via
+  // `turbopack.resolveExtensions` above; webpack needs `extensionAlias`.
+  webpack(config) {
+    config.resolve = config.resolve || {}
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias || {}),
       '.js': ['.ts', '.tsx', '.js', '.jsx'],
-    },
+      '.mjs': ['.mts', '.mjs'],
+    }
+    return config
   },
   // Security headers (from current vercel.json)
   async headers() {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -376,7 +376,7 @@ async function seed() {
       description: "Foster resilience and growth mindset in all students",
       level: 1,
       orderPosition: 4,
-      status: "completed",
+      status: "complete",
       overallProgress: "100.00",
     },
     {
@@ -390,7 +390,7 @@ async function seed() {
         "Increase student engagement and reduce chronic absenteeism",
       level: 1,
       orderPosition: 5,
-      status: "on_hold",
+      status: "in_progress",
       overallProgress: "35.00",
     },
     {
@@ -422,7 +422,7 @@ async function seed() {
         "Establish strong reading foundations in grades K-2 with 90% meeting benchmarks",
       level: 2,
       orderPosition: 1,
-      status: "completed",
+      status: "complete",
       overallProgress: "95.00",
     },
     {
@@ -529,7 +529,7 @@ async function seed() {
         "Effectively integrate technology to enhance learning outcomes",
       level: 1,
       orderPosition: 2,
-      status: "completed",
+      status: "complete",
       overallProgress: "100.00",
     },
     {
@@ -653,7 +653,7 @@ async function seed() {
         "Upgrade and maintain district facilities to support modern learning",
       level: 1,
       orderPosition: 2,
-      status: "on_hold",
+      status: "in_progress",
       overallProgress: "20.00",
     },
   ]);
@@ -783,7 +783,7 @@ async function seed() {
         "Implement cross-curricular literacy strategies in all subjects",
       level: 1,
       orderPosition: 2,
-      status: "completed",
+      status: "complete",
       overallProgress: "92.00",
     },
   ]);
@@ -879,7 +879,7 @@ async function seed() {
       "Ensure equitable access to high-quality education for every student regardless of background",
     level: 0,
     orderPosition: 4,
-    status: "on_hold",
+    status: "in_progress",
     overallProgress: "30.00",
     overallProgressDisplayMode: "hidden",
   });
@@ -897,7 +897,7 @@ async function seed() {
         "Provide 1:1 devices and reliable internet access for all students",
       level: 1,
       orderPosition: 1,
-      status: "on_hold",
+      status: "in_progress",
       overallProgress: "25.00",
     },
     {
@@ -1059,7 +1059,7 @@ async function seed() {
         "Implement competitive challenge programs that build career-ready skills",
       level: 1,
       orderPosition: 2,
-      status: "completed",
+      status: "complete",
       overallProgress: "82.00",
     },
   ]);

--- a/src/components/v2/public/GoalMetricCard.tsx
+++ b/src/components/v2/public/GoalMetricCard.tsx
@@ -31,8 +31,11 @@ function progressBarColor(status?: string): string {
   switch (status?.toLowerCase().replace(/\s+/g, '_')) {
     case 'on_target':
     case 'on target':
+    case 'on_track':
+    case 'on track':
     case 'exceeding':
     case 'completed':
+    case 'complete':
       return 'bg-emerald-500';
     case 'at_risk':
     case 'at risk':

--- a/src/components/v2/public/GoalStatusBadge.tsx
+++ b/src/components/v2/public/GoalStatusBadge.tsx
@@ -4,6 +4,11 @@ export interface GoalStatusBadgeProps {
 }
 
 const STATUS_MAP: Record<string, { label: string; bgColor: string; textColor: string }> = {
+  // design.md §5.3 values
+  on_track: { label: 'On Track', bgColor: '#dcfce7', textColor: '#166534' },
+  off_track: { label: 'Off Track', bgColor: '#fee2e2', textColor: '#991b1b' },
+  complete: { label: 'Complete', bgColor: '#dcfce7', textColor: '#166534' },
+  // legacy values still emitted by some pre-v4 code paths
   completed: { label: 'Completed', bgColor: '#dcfce7', textColor: '#166534' },
   'on-target': { label: 'On Target', bgColor: '#dcfce7', textColor: '#166534' },
   in_progress: { label: 'In Progress', bgColor: '#fef3c7', textColor: '#92400e' },

--- a/src/components/v2/public/SubGoalAccordion.tsx
+++ b/src/components/v2/public/SubGoalAccordion.tsx
@@ -23,9 +23,11 @@ export interface SubGoalAccordionProps {
 function statusLabel(status?: string): { label: string; color: string } {
   switch (status?.toLowerCase().replace(/\s+/g, '_')) {
     case 'completed':
+    case 'complete':
     case 'on_target':
+    case 'on_track':
     case 'exceeding':
-      return { label: 'Completed', color: 'text-md3-secondary' };
+      return { label: 'Complete', color: 'text-md3-secondary' };
     case 'in_progress':
     case 'at_risk':
       return { label: 'In Progress', color: 'text-md3-tertiary' };

--- a/src/components/v2/tree/AddGoalInline.tsx
+++ b/src/components/v2/tree/AddGoalInline.tsx
@@ -5,7 +5,7 @@ interface AddGoalInlineProps {
   planId: string;
   districtId: string;
   parentId: string | null;
-  level: 0 | 1 | 2;
+  level: 0 | 1 | 2 | 3;
   onCancel: () => void;
 }
 

--- a/src/components/v2/tree/GoalTreeItem.tsx
+++ b/src/components/v2/tree/GoalTreeItem.tsx
@@ -15,8 +15,9 @@ interface GoalTreeItemProps {
 const STATUS_OPTIONS = [
   { value: 'not_started', label: 'Not Started' },
   { value: 'in_progress', label: 'In Progress' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'on_hold', label: 'On Hold' },
+  { value: 'on_track', label: 'On Track' },
+  { value: 'off_track', label: 'Off Track' },
+  { value: 'complete', label: 'Complete' },
 ] as const;
 
 const LEVEL_BADGE_STYLES: Record<number, { bg: string; text: string; label: string }> = {
@@ -154,8 +155,8 @@ export function GoalTreeItem({ goal, planId, districtId }: GoalTreeItemProps) {
           <ExternalLink className="h-4 w-4" />
         </button>
 
-        {/* Add sub-goal button (only for L0 and L1) */}
-        {goal.level < 2 && (
+        {/* Add sub-goal button (only for L0–L2; design.md §5.8 caps nesting at level 3) */}
+        {goal.level < 3 && (
           <button
             onClick={() => setShowAddChild(!showAddChild)}
             className="opacity-0 group-hover:opacity-100 p-1 rounded transition-opacity"

--- a/src/components/v2/tree/__tests__/GoalTreeItem.test.tsx
+++ b/src/components/v2/tree/__tests__/GoalTreeItem.test.tsx
@@ -94,8 +94,9 @@ describe('GoalTreeItem', () => {
     const statusSelect = screen.getByDisplayValue('In Progress');
     expect(statusSelect).toBeInTheDocument();
     expect(screen.getByText('Not Started')).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
-    expect(screen.getByText('On Hold')).toBeInTheDocument();
+    expect(screen.getByText('On Track')).toBeInTheDocument();
+    expect(screen.getByText('Off Track')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
   });
 
   it('enters edit mode when title is clicked', async () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,7 +76,7 @@ export interface Goal {
   goal_number: string;
   title: string;
   description?: string;
-  level: 0 | 1 | 2;
+  level: 0 | 1 | 2 | 3;
   order_position: number;
   created_at: string;
   updated_at: string;
@@ -143,7 +143,7 @@ export function buildGoalHierarchy(goals: Goal[]): HierarchicalGoal[] {
 export function getNextGoalNumber(
   goals: Goal[],
   parentId: string | null,
-  level: 0 | 1 | 2
+  level: 0 | 1 | 2 | 3
 ): string {
   const siblingGoals = goals.filter(
     g => g.parent_id === parentId && g.level === level

--- a/src/lib/types/import.types.ts
+++ b/src/lib/types/import.types.ts
@@ -96,7 +96,7 @@ export interface ParsedGoal {
   goal_number: string; // "1.1.1"
   title: string;
   description?: string;
-  level: 0 | 1 | 2;
+  level: 0 | 1 | 2 | 3;
   owner_name?: string;
   metrics: ParsedMetric[];
 }

--- a/src/lib/types/v2.ts
+++ b/src/lib/types/v2.ts
@@ -77,9 +77,10 @@ export interface V2Goal {
   goalNumber: string;
   title: string;
   description?: string;
-  level: 0 | 1 | 2;
+  level: 0 | 1 | 2 | 3;
   orderPosition: number;
-  status: 'not_started' | 'in_progress' | 'completed' | 'on_hold';
+  // Matches the DB CHECK constraint (design.md §5.3 — locked to this set).
+  status: 'not_started' | 'in_progress' | 'on_track' | 'off_track' | 'complete';
   progress: number;
   ownerId?: string;
   ownerName?: string;

--- a/src/lib/utils/goalHealth.ts
+++ b/src/lib/utils/goalHealth.ts
@@ -19,8 +19,10 @@ export interface HealthSegment {
 function normalizeStatus(status?: string): 'on_target' | 'at_risk' | 'critical' | 'no_data' {
   switch (status?.toLowerCase().replace(/\s+/g, '_')) {
     case 'on_target':
+    case 'on_track':
     case 'exceeding':
     case 'completed':
+    case 'complete':
       return 'on_target';
     case 'at_risk':
     case 'in_progress':

--- a/src/views/dashboard/UserDashboard.tsx
+++ b/src/views/dashboard/UserDashboard.tsx
@@ -526,8 +526,9 @@ function PlanRow({ plan, districtName, districtColor, isSelected, onClick, onNav
 function getStatusColor(status?: string): string {
   switch (status) {
     case 'in_progress': return '#3b82f6';
-    case 'completed': return '#22c55e';
-    case 'on_hold': return '#f59e0b';
+    case 'on_track':
+    case 'complete': return '#22c55e';
+    case 'off_track': return '#f59e0b';
     case 'not_started': return '#9ca3af';
     default: return '#9ca3af';
   }

--- a/src/views/v2/admin/V2AdminDashboard.tsx
+++ b/src/views/v2/admin/V2AdminDashboard.tsx
@@ -17,7 +17,7 @@ function countGoals(goals: HierarchicalGoal[]): { total: number; completed: numb
   function walk(nodes: HierarchicalGoal[]) {
     for (const g of nodes) {
       total++;
-      if (g.status === 'completed') completed++;
+      if (g.status === 'complete') completed++;
       if (g.children) walk(g.children);
     }
   }

--- a/src/views/v2/admin/V2GoalDetail.tsx
+++ b/src/views/v2/admin/V2GoalDetail.tsx
@@ -26,8 +26,9 @@ function findGoalInHierarchy(goals: HierarchicalGoal[], id: string): Hierarchica
 const STATUS_OPTIONS = [
   { value: 'not_started', label: 'Not Started' },
   { value: 'in_progress', label: 'In Progress' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'on_hold', label: 'On Hold' },
+  { value: 'on_track', label: 'On Track' },
+  { value: 'off_track', label: 'Off Track' },
+  { value: 'complete', label: 'Complete' },
 ] as const;
 
 const PRIORITY_OPTIONS = [

--- a/src/views/v2/admin/__tests__/V2GoalDetail.test.tsx
+++ b/src/views/v2/admin/__tests__/V2GoalDetail.test.tsx
@@ -211,11 +211,11 @@ describe('V2GoalDetail', () => {
     render(<V2GoalDetail />);
 
     const statusSelect = screen.getByDisplayValue('In Progress');
-    await user.selectOptions(statusSelect, 'completed');
+    await user.selectOptions(statusSelect, 'complete');
 
     expect(mockUpdateGoalMutate).toHaveBeenCalledWith({
       id: 'goal-1',
-      updates: { status: 'completed' },
+      updates: { status: 'complete' },
     });
   });
 

--- a/src/views/v2/public/ObjectiveDetailView.tsx
+++ b/src/views/v2/public/ObjectiveDetailView.tsx
@@ -12,7 +12,7 @@ import type { Widget } from '@/lib/types/v2';
 
 function statusDotChar(status?: string): string {
   const s = status?.toLowerCase().replace(/\s+/g, '_');
-  if (s === 'on_target' || s === 'exceeding' || s === 'completed') return 'text-emerald-500';
+  if (s === 'on_target' || s === 'on_track' || s === 'exceeding' || s === 'completed' || s === 'complete') return 'text-emerald-500';
   if (s === 'at_risk' || s === 'in_progress') return 'text-amber-500';
   if (s === 'critical' || s === 'off_track') return 'text-red-500';
   return 'text-slate-300';

--- a/src/views/v2/public/ObjectivesOverviewView.tsx
+++ b/src/views/v2/public/ObjectivesOverviewView.tsx
@@ -14,7 +14,7 @@ const ACCENT_COLORS = ['#702ae1', '#00675d', '#005950', '#D97706'];
 function statusDotsForGoals(children: HierarchicalGoal[]): { color: string }[] {
   return children.map((c) => {
     const s = c.status?.toLowerCase().replace(/\s+/g, '_');
-    if (s === 'on_target' || s === 'exceeding' || s === 'completed') return { color: 'bg-emerald-500' };
+    if (s === 'on_target' || s === 'on_track' || s === 'exceeding' || s === 'completed' || s === 'complete') return { color: 'bg-emerald-500' };
     if (s === 'at_risk' || s === 'in_progress') return { color: 'bg-amber-500' };
     if (s === 'critical' || s === 'off_track') return { color: 'bg-red-500' };
     return { color: 'bg-slate-200' };

--- a/src/views/v2/public/PlanLandingView.tsx
+++ b/src/views/v2/public/PlanLandingView.tsx
@@ -22,7 +22,7 @@ const OBJECTIVE_ICON_CLASSES = [
 function statusDotsForGoals(children: HierarchicalGoal[]): { color: string }[] {
   return children.map((c) => {
     const s = c.status?.toLowerCase().replace(/\s+/g, '_');
-    if (s === 'on_target' || s === 'exceeding' || s === 'completed') return { color: 'bg-emerald-500' };
+    if (s === 'on_target' || s === 'on_track' || s === 'exceeding' || s === 'completed' || s === 'complete') return { color: 'bg-emerald-500' };
     if (s === 'at_risk' || s === 'in_progress') return { color: 'bg-amber-500' };
     if (s === 'critical' || s === 'off_track') return { color: 'bg-red-500' };
     return { color: 'border border-slate-300' };


### PR DESCRIPTION
## Summary

Phase 1 of the v4 public dashboard work: reconciles the `goals` schema with everything `design.md` now requires, plus a webpack-config fix needed to keep the API routes compiling.

### Schema additions (migration 0009)

- `goals.narrative` — expanded Pattern A row green-tinted callout (any level)
- `goals.pull_quote_text` + `pull_quote_attribution` — per-objective pull quote (§5.13)
- `goals.highlight_stats` (jsonb) — 3-up stat callouts under the left narrative column, fetchable alongside the objective in one round trip (§6.2)
- `goals.signature_widget_id` (uuid FK → `widgets.id`, `ON DELETE SET NULL`, indexed) — §5.7 right-column hero card pointer
- `goals_status_check` CHECK constraint locking `status` to the design.md §5.3 set: `on_track`, `in_progress`, `off_track`, `complete`, `not_started`. Pre-check UPDATEs map legacy rows (`completed→complete`, `on_hold→in_progress`, stray values → `not_started`).

### Code changes driven by the schema

- Admin UI level cap lifted from `goal.level < 2` to `< 3` in `GoalTreeItem.tsx` so §5.8's 3-level hierarchy (3.1.2.1) is creatable.
- Widened `level` TS types from `0|1|2` to `0|1|2|3` across `Goal`, `V2Goal`, `ParsedGoal`, `AddGoalInline`, and `getNextGoalNumber`.
- Narrowed `V2Goal.status` to the design set; updated call sites: V2GoalDetail + GoalTreeItem status dropdowns, V2AdminDashboard counter, `goalHealth.ts` normalizer, public views (ObjectiveDetailView, ObjectivesOverviewView, PlanLandingView, SubGoalAccordion, GoalMetricCard, UserDashboard), and `GoalStatusBadge.STATUS_MAP`.
- Seed updated: `completed→complete`, `on_hold→in_progress`.
- Tests updated: `GoalTreeItem.test.tsx` and `V2GoalDetail.test.tsx` now assert the design-set labels.

### Build fix (next.config.ts)

Restores webpack `.js→.ts` extension resolution via a `webpack()` override using `extensionAlias`. Without it, every `_api/**/route.ts` compile fails with `Module not found: Can't resolve './goals.js'` because `_api/lib/schema/*.ts` files import each other as `./goals.js` (required for Better Auth + Vercel ESM runtime). Turbopack already had parity via `turbopack.resolveExtensions`; webpack did not.

## Test plan

- [x] `npx drizzle-kit migrate` against the Neon dev branch — applies cleanly
- [x] DB verification: 5 new columns present, `goals_status_check` CHECK + `goals_signature_widget_id_widgets_id_fk` FK + `goals_signature_widget_id_idx` index all present, post-migration distinct statuses are `{not_started, in_progress, complete}`
- [x] `npm run db:seed:fresh` — 48 goals, 44 widgets seed cleanly under the new constraint
- [x] `npm run test:run` — 890/890 passing
- [x] `npm run build` — webpack build green; API routes compile
- [ ] Vercel preview deployment smoke test (login, load westside plan page, confirm no regressions)
- [ ] Spot-check admin can now add a level-3 sub-goal via the tree UI

## Follow-ups (out of scope for this PR)

- Wire the new columns into the service layer + React Query hooks (Phase 2)
- Render the signature metric card, pull quote, narrative callouts, and highlight stats in the public dashboard (Phase 3)
- Sweep remaining legacy `'completed'` / `'on_hold'` references in non-v2 code paths if/when those views migrate to the design set

🤖 Generated with [Claude Code](https://claude.com/claude-code)