### PR TITLE
chore(ci): gate main deploys on prod Neon migration status

### DIFF
--- a/.github/workflows/__tests__/prod-db.test.ts
+++ b/.github/workflows/__tests__/prod-db.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKFLOW_PATH = resolve(__dirname, '..', 'prod-db.yml');
+
+describe('prod-db.yml workflow (Issue #166 — gate prod deploys on Neon migration status)', () => {
+  it('exists at .github/workflows/prod-db.yml', () => {
+    expect(existsSync(WORKFLOW_PATH)).toBe(true);
+  });
+
+  describe('contents', () => {
+    const yaml = existsSync(WORKFLOW_PATH) ? readFileSync(WORKFLOW_PATH, 'utf-8') : '';
+
+    it('triggers on push to main', () => {
+      expect(yaml).toMatch(/on:\s*[\s\S]*push:\s*[\s\S]*branches:\s*\[\s*main\s*\]/);
+    });
+
+    it('only runs when migrations or schema actually change (paths filter)', () => {
+      expect(yaml).toContain('drizzle/migrations/**');
+      expect(yaml).toContain('drizzle/custom/**');
+      expect(yaml).toContain('_api/lib/schema/**');
+    });
+
+    it('supports manual replay via workflow_dispatch', () => {
+      expect(yaml).toContain('workflow_dispatch');
+    });
+
+    it('serializes prod migration runs (concurrency group, no cancel)', () => {
+      expect(yaml).toMatch(/concurrency:\s*[\s\S]*group:\s*prod-db-migrate/);
+      expect(yaml).toMatch(/cancel-in-progress:\s*false/);
+    });
+
+    it('uses the Production GitHub environment for secret scoping + future approval rules', () => {
+      expect(yaml).toMatch(/environment:\s*Production/);
+    });
+
+    it('runs drizzle-kit migrate against secrets.DATABASE_URL', () => {
+      expect(yaml).toContain('npx drizzle-kit migrate');
+      expect(yaml).toContain('${{ secrets.DATABASE_URL }}');
+    });
+
+    it('applies the updated_at trigger SQL (idempotent)', () => {
+      expect(yaml).toContain('drizzle/custom/0001_updated_at_trigger.sql');
+    });
+
+    it('opens a labeled GitHub Issue on failure (loud signal vs silent prod break)', () => {
+      expect(yaml).toMatch(/if:\s*failure\(\)/);
+      expect(yaml).toContain('actions/github-script');
+      expect(yaml).toContain('prod-incident');
+    });
+  });
+});

--- a/.github/workflows/__tests__/prod-db.test.ts
+++ b/.github/workflows/__tests__/prod-db.test.ts
@@ -9,8 +9,11 @@ describe('prod-db.yml workflow (Issue #166 — gate prod deploys on Neon migrati
     expect(existsSync(WORKFLOW_PATH)).toBe(true);
   });
 
-  describe('contents', () => {
-    const yaml = existsSync(WORKFLOW_PATH) ? readFileSync(WORKFLOW_PATH, 'utf-8') : '';
+  // Short-circuit the content checks when the file is missing — the existence
+  // test above already reports that cleanly, and 8 more assertions against
+  // an empty string just adds noise.
+  describe.skipIf(!existsSync(WORKFLOW_PATH))('contents', () => {
+    const yaml = readFileSync(WORKFLOW_PATH, 'utf-8');
 
     it('triggers on push to main', () => {
       expect(yaml).toMatch(/on:\s*[\s\S]*push:\s*[\s\S]*branches:\s*\[\s*main\s*\]/);

--- a/.github/workflows/prod-db.yml
+++ b/.github/workflows/prod-db.yml
@@ -1,0 +1,84 @@
+name: Production Database
+
+# Issue #166: Gate prod deploys on Neon migration status.
+# Mirrors preview-db.yml, but runs against prod Neon `main` on push to main.
+# If migrations fail, opens a `prod-incident` issue and fails the workflow —
+# the red X on the commit is the operator's signal to reconcile prod before
+# users hit the broken Vercel deploy.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'drizzle/migrations/**'
+      - 'drizzle/custom/**'
+      - '_api/lib/schema/**'
+      - '.github/workflows/prod-db.yml'
+  workflow_dispatch:
+
+# Never run two `drizzle-kit migrate` invocations against prod simultaneously.
+concurrency:
+  group: prod-db-migrate
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  migrate-prod-db:
+    name: Apply Migrations to Production Neon
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run Drizzle migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx drizzle-kit migrate
+
+      - name: Apply trigger SQL (idempotent)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: psql "$DATABASE_URL" -f drizzle/custom/0001_updated_at_trigger.sql
+
+      - name: Open prod-incident issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha.slice(0, 7);
+            const body = [
+              '## Production migration FAILED',
+              '',
+              `Commit: \`${sha}\``,
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'The Vercel production deploy for this commit will ship code that may reference',
+              'columns or tables that do not exist in prod Neon. Investigate before users hit it:',
+              '',
+              '1. Check the workflow logs for the drizzle-kit migrate output',
+              '2. If safe, re-run via Actions tab → Production Database → Run workflow',
+              '3. If a migration is broken, revert the commit and apply a fix on a new PR',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `prod-db migration failed on ${sha}`,
+              body,
+              labels: ['prod-incident'],
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,12 @@ Test users are created via the seed script (`scripts/seed.ts`) using Better Auth
 - [ ] All tests passing
 - [ ] No destructive operations without backup plan
 
+### Journal Drift (known issue, 2026-04)
+
+Prod Neon `main`'s Drizzle journal records all 10 migrations as applied, but `0009_v4_dashboard_schema.sql` was applied out-of-band via `psql` (Issue #166 incident) without updating the journal-writer's state. **Future `drizzle-kit migrate` runs against prod will skip `0009` because the journal says it's done.** This is safe today because every migration uses `IF NOT EXISTS` / `DROP CONSTRAINT IF EXISTS` — replay is a no-op.
+
+**When this becomes unsafe:** the first migration that uses a non-idempotent statement (e.g. `INSERT` of seed data, `UPDATE` of existing rows). Before merging such a migration, reconcile via `drizzle-kit introspect` against prod and produce a baseline migration.
+
 ## CI Pipeline
 
 Pull requests are validated via GitHub Actions.
@@ -258,6 +264,16 @@ lint-typecheck
 1. **Linting & Type checking** - ESLint + TypeScript compiler
 2. **Unit tests** - Vitest test suite
 3. **Build** - Production build completes successfully
+
+### CI Invariant
+
+**If `main` CI is green, prod Neon is at HEAD's migration state.**
+
+The `prod-db.yml` workflow runs on every push to `main` that touches `drizzle/migrations/`, `drizzle/custom/`, `_api/lib/schema/`, or the workflow itself. It applies pending migrations to prod Neon via `drizzle-kit migrate` before signaling success. If migrations fail, the workflow opens a `prod-incident` labeled issue and the commit shows a red X — the operator must reconcile prod Neon before users hit the broken Vercel deploy.
+
+**This invariant only holds for paths the workflow watches.** Out-of-band schema changes (manual `psql` against prod, schema edits not accompanied by a generated migration) bypass the gate. Always run `npx drizzle-kit generate` after editing files in `_api/lib/schema/`.
+
+This invariant exists because of [Issue #166](https://github.com/ptoney514/strategic-plan-app/issues/166): PR #162 shipped code referencing columns that didn't exist in prod, taking every public district page dark for ~a week.
 
 ## Preview/Staging Workflow
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/prod-db.yml` — on push to `main`, runs `drizzle-kit migrate` against prod Neon before Vercel's deploy completes. If migrations fail, opens a `prod-incident` labeled issue so the red X isn't the only signal.
- Add `CLAUDE.md` "CI Invariant" section: _if `main` CI is green, prod Neon is at HEAD's migration state_. Plus a "Journal Drift" note documenting the out-of-band `0009` apply from the incident.
- Add `DATABASE_URL` repo secret (was referenced by `backup.yml` already but missing — this also un-breaks the weekly backup).

Mirrors the existing `preview-db.yml` structure so future maintainers recognize the pattern. The workflow's `paths:` filter keeps it from firing on doc-only commits; `concurrency: prod-db-migrate` serializes runs so two commits can't race `drizzle-kit migrate`.

## Why

PR #162 landed migration `0009_v4_dashboard_schema.sql` (added `narrative`, `pull_quote_text`, `highlight_stats`, `signature_widget_id` to `goals`). Vercel shipped the code that `SELECT`s those columns. Nobody applied the migration to prod Neon. **Every `/district/[slug]` page returned zero goals for ~a week** — noticed during PR #165's merge verification. Fixed manually with `psql -f`.

## Honest tradeoff

The workflow does NOT physically halt the Vercel deploy (that requires Vercel Pro deployment protection). It fails loudly: red X on the commit + auto-opened `prod-incident` issue. Next migration that reaches prod tests this for real.

## Test plan

- [x] Vitest: 9 new tests in `.github/workflows/__tests__/prod-db.test.ts` assert workflow shape (triggers, paths filter, concurrency, env, migrate step, trigger SQL step, failure handler) — written red, now green
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/prod-db.yml'))"`)
- [x] `DATABASE_URL` secret set at repo level (visible in `gh secret list`)
- [ ] After merge: Actions tab → Production Database → Run workflow on `main`. Expect green + "No pending migrations" in `drizzle-kit migrate` output
- [ ] Optional tightening: move `DATABASE_URL` from repo-level to the `Production` GitHub Environment for scoped access + add required-reviewer rule

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)