### PR TITLE
feat: env-gated maintenance mode with subdomain bypass

### DIFF
--- a/docs/maintenance-mode.md
+++ b/docs/maintenance-mode.md
@@ -1,0 +1,101 @@
+# Maintenance Mode
+
+A toggle that shows a "We'll be right back" page to every visitor on production while you keep working normally on preview deployments and local dev. Useful when you want to polish public pages without clients viewing them mid-change.
+
+## How it works
+
+- `src/middleware.ts` checks `MAINTENANCE_MODE` on every page request. When `true`, it rewrites the response to `/maintenance` with HTTP status `503`.
+- `src/app/maintenance/page.tsx` is the holding page that visitors see.
+- `src/app/maintenance-bypass/route.ts` sets a cookie that lets you skip the gate — so you can still view the real site on production.
+- API routes (`/api/*`), Next.js internals (`/_next/*`), and static assets pass through unchanged, so the maintenance page itself loads correctly.
+
+The gate runs **before** subdomain routing, so it covers `stratadash.org`, `westside.stratadash.org`, `admin.stratadash.org`, and every other subdomain with a single flag.
+
+## Environment variables
+
+| Variable                 | Scope      | Value                                        |
+| ------------------------ | ---------- | -------------------------------------------- |
+| `MAINTENANCE_MODE`       | Production | `true` to enable, unset/`false` to disable   |
+| `MAINTENANCE_BYPASS_KEY` | Production | A long random string (treat like a password) |
+
+Leave both unset on Preview and Development scopes. That way PR previews and `npm run dev` are never gated.
+
+## Turning maintenance mode ON
+
+```bash
+# From the project root, with Vercel CLI installed and linked
+printf 'true' | vercel env add MAINTENANCE_MODE production
+printf '%s' "$(openssl rand -hex 24)" | vercel env add MAINTENANCE_BYPASS_KEY production
+
+# Save the bypass key somewhere you can find it — you'll need it to view prod.
+vercel env pull .env.vercel-production --environment production
+grep MAINTENANCE_BYPASS_KEY .env.vercel-production
+```
+
+Trigger a redeploy so the new env vars take effect:
+
+```bash
+git commit --allow-empty -m "chore: enable maintenance mode"
+git push origin main
+```
+
+(Or redeploy from the Vercel dashboard.)
+
+Verify: visit `https://www.stratadash.org` in an incognito window — you should see the maintenance page and a `503` status in devtools.
+
+## Viewing production while maintenance is on
+
+Visit this URL once (replace `YOUR_KEY` with the value of `MAINTENANCE_BYPASS_KEY`):
+
+```
+https://www.stratadash.org/maintenance-bypass?key=YOUR_KEY
+```
+
+You'll be redirected to `/` and a `maintenance_bypass` cookie is set for 30 days on the registrable domain (e.g. `.stratadash.org`). That means **one visit unlocks every subdomain** — `www.stratadash.org`, `westside.stratadash.org`, `admin.stratadash.org`, etc. — from the same browser.
+
+To revoke: clear cookies for `stratadash.org`, or rotate `MAINTENANCE_BYPASS_KEY` and redeploy (the old cookie stops matching).
+
+## Turning maintenance mode OFF
+
+```bash
+vercel env rm MAINTENANCE_MODE production
+# Optionally remove the bypass key too:
+vercel env rm MAINTENANCE_BYPASS_KEY production
+```
+
+Redeploy:
+
+```bash
+git commit --allow-empty -m "chore: disable maintenance mode"
+git push origin main
+```
+
+## Testing locally
+
+```bash
+# .env.local
+MAINTENANCE_MODE=true
+MAINTENANCE_BYPASS_KEY=local-dev-key
+```
+
+```bash
+npm run dev
+```
+
+- `http://localhost:5174` → maintenance page (503)
+- `http://localhost:5174/maintenance-bypass?key=local-dev-key` → sets cookie, redirects home
+- Remove the env vars from `.env.local` when you're done.
+
+## Why this design
+
+- **Single env var toggle** — flip one value, no code changes, no branch swaps.
+- **Preview deploys unaffected** — env var is only set on Production scope, so every PR preview shows the real app for you and stakeholders you share links with.
+- **Gates everything** — public pages, admin, and district subdomains all covered by one middleware check that runs before any subdomain routing.
+- **Bypass cookie** — lets you keep working on production (testing, QA, sharing with specific people) without flipping the flag off.
+- **HTTP 503 + `noindex`** — tells search engines and uptime monitors this is temporary, not a real outage or removal.
+
+## Files
+
+- `src/middleware.ts` — the gate logic (search for "Maintenance gate")
+- `src/app/maintenance/page.tsx` — the holding page
+- `src/app/maintenance-bypass/route.ts` — the bypass cookie setter

--- a/src/app/maintenance-bypass/route.ts
+++ b/src/app/maintenance-bypass/route.ts
@@ -1,21 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCookieDomain } from '@/lib/cookie-domain'
+import { MAINTENANCE_COOKIE_NAME } from '@/lib/maintenance'
 
-const COOKIE_NAME = 'maintenance_bypass'
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
-
-// Return the registrable domain to scope the cookie across subdomains.
-// "www.stratadash.org" → ".stratadash.org", "westside.lvh.me" → ".lvh.me".
-// For localhost / vercel preview hosts, return undefined so the browser
-// scopes the cookie to the exact host.
-function resolveCookieDomain(host: string): string | undefined {
-  const bare = host.split(':')[0]
-  if (bare === 'localhost' || bare === '127.0.0.1') return undefined
-  if (bare.endsWith('.vercel.app') || bare === 'vercel.app') return undefined
-
-  const parts = bare.split('.')
-  if (parts.length < 2) return undefined
-  return `.${parts.slice(-2).join('.')}`
-}
 
 export function GET(request: NextRequest) {
   const key = request.nextUrl.searchParams.get('key')
@@ -26,10 +13,10 @@ export function GET(request: NextRequest) {
   }
 
   const host = request.headers.get('host') ?? ''
-  const domain = resolveCookieDomain(host)
+  const domain = getCookieDomain(host)
 
   const response = NextResponse.redirect(new URL('/', request.url))
-  response.cookies.set(COOKIE_NAME, expected, {
+  response.cookies.set(MAINTENANCE_COOKIE_NAME, expected, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',

--- a/src/app/maintenance-bypass/route.ts
+++ b/src/app/maintenance-bypass/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const COOKIE_NAME = 'maintenance_bypass'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
+
+// Return the registrable domain to scope the cookie across subdomains.
+// "www.stratadash.org" → ".stratadash.org", "westside.lvh.me" → ".lvh.me".
+// For localhost / vercel preview hosts, return undefined so the browser
+// scopes the cookie to the exact host.
+function resolveCookieDomain(host: string): string | undefined {
+  const bare = host.split(':')[0]
+  if (bare === 'localhost' || bare === '127.0.0.1') return undefined
+  if (bare.endsWith('.vercel.app') || bare === 'vercel.app') return undefined
+
+  const parts = bare.split('.')
+  if (parts.length < 2) return undefined
+  return `.${parts.slice(-2).join('.')}`
+}
+
+export function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key')
+  const expected = process.env.MAINTENANCE_BYPASS_KEY
+
+  if (!expected || key !== expected) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  const host = request.headers.get('host') ?? ''
+  const domain = resolveCookieDomain(host)
+
+  const response = NextResponse.redirect(new URL('/', request.url))
+  response.cookies.set(COOKIE_NAME, expected, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: COOKIE_MAX_AGE,
+    path: '/',
+    domain,
+  })
+  return response
+}

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Scheduled Maintenance — StrataDASH',
+  description: 'StrataDASH is undergoing scheduled maintenance. We will be back shortly.',
+  robots: { index: false, follow: false },
+}
+
+export default function MaintenancePage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 flex items-center justify-center px-6 py-12">
+      <div className="max-w-xl w-full text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-slate-900 text-white font-[family-name:var(--font-sora)] text-2xl font-semibold mb-8">
+          S
+        </div>
+
+        <h1 className="font-[family-name:var(--font-sora)] text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 mb-4">
+          We&rsquo;ll be right back.
+        </h1>
+
+        <p className="text-lg text-slate-600 leading-relaxed mb-8">
+          StrataDASH is undergoing scheduled maintenance as we polish a few things.
+          Thanks for your patience — we&rsquo;ll be back online shortly.
+        </p>
+
+        <div className="inline-flex items-center gap-2 text-sm text-slate-500 bg-white border border-slate-200 rounded-full px-4 py-2">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500"></span>
+          </span>
+          Status: Maintenance in progress
+        </div>
+
+        <p className="mt-12 text-sm text-slate-400">
+          Questions? Email{' '}
+          <a href="mailto:support@stratadash.org" className="text-slate-600 hover:text-slate-900 underline underline-offset-2">
+            support@stratadash.org
+          </a>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/lib/__tests__/cookie-domain.test.ts
+++ b/src/lib/__tests__/cookie-domain.test.ts
@@ -107,4 +107,26 @@ describe('getCookieDomain', () => {
       expect(getCookieDomain()).toBeUndefined();
     });
   });
+
+  describe('explicit hostname (server-side callers)', () => {
+    it('resolves production hosts', () => {
+      expect(getCookieDomain('westside.stratadash.org')).toBe('.stratadash.org');
+      expect(getCookieDomain('www.stratadash.org')).toBe('.stratadash.org');
+    });
+
+    it('resolves lvh.me hosts', () => {
+      expect(getCookieDomain('admin.lvh.me')).toBe('.lvh.me');
+    });
+
+    it('strips a port from the host header before matching', () => {
+      expect(getCookieDomain('westside.stratadash.org:443')).toBe('.stratadash.org');
+      expect(getCookieDomain('lvh.me:5174')).toBe('.lvh.me');
+    });
+
+    it('returns undefined for localhost and vercel preview hosts', () => {
+      expect(getCookieDomain('localhost')).toBeUndefined();
+      expect(getCookieDomain('localhost:5174')).toBeUndefined();
+      expect(getCookieDomain('my-app.vercel.app')).toBeUndefined();
+    });
+  });
 });

--- a/src/lib/cookie-domain.ts
+++ b/src/lib/cookie-domain.ts
@@ -2,23 +2,24 @@
  * Determines the cookie domain for cross-subdomain authentication.
  * - Production: .stratadash.org (allows cookies to be shared across all subdomains)
  * - Local dev: .lvh.me (resolves to 127.0.0.1, enables local subdomain testing)
- * - Localhost: undefined (cookies scoped to current domain only)
+ * - Localhost / Vercel preview: undefined (cookies scoped to current host only)
+ *
+ * Pass a hostname explicitly when called from the server (middleware, route
+ * handlers). With no argument, reads `window.location.hostname` on the client.
  */
-export function getCookieDomain(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
+export function getCookieDomain(hostname?: string): string | undefined {
+  const host = hostname ?? (typeof window === 'undefined' ? undefined : window.location.hostname);
+  if (!host) return undefined;
 
-  const hostname = window.location.hostname;
+  const bare = host.split(':')[0];
 
-  // Production: share cookies across all *.stratadash.org subdomains
-  if (hostname.endsWith('stratadash.org')) {
+  if (bare.endsWith('stratadash.org')) {
     return '.stratadash.org';
   }
 
-  // Local development with lvh.me (resolves to 127.0.0.1)
-  if (hostname.endsWith('.lvh.me') || hostname === 'lvh.me') {
+  if (bare.endsWith('.lvh.me') || bare === 'lvh.me') {
     return '.lvh.me';
   }
 
-  // localhost or IP addresses: cannot share cookies across subdomains
   return undefined;
 }

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -1,0 +1,1 @@
+export const MAINTENANCE_COOKIE_NAME = 'maintenance_bypass'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,6 +32,28 @@ export function middleware(request: NextRequest) {
     return NextResponse.next()
   }
 
+  // --- Maintenance gate ---
+  // When MAINTENANCE_MODE=true, rewrite every page request to /maintenance
+  // unless the request carries a valid bypass cookie or targets the bypass route.
+  if (process.env.MAINTENANCE_MODE === 'true') {
+    const bypassKey = process.env.MAINTENANCE_BYPASS_KEY
+    const bypassCookie = request.cookies.get('maintenance_bypass')?.value
+    const hasBypass = Boolean(bypassKey) && bypassCookie === bypassKey
+
+    const isMaintenanceRoute =
+      pathname === '/maintenance' || pathname === '/maintenance-bypass'
+
+    if (!hasBypass && !isMaintenanceRoute) {
+      url.pathname = '/maintenance'
+      return NextResponse.rewrite(url, { status: 503 })
+    }
+
+    if (hasBypass && pathname === '/maintenance') {
+      url.pathname = '/'
+      return NextResponse.redirect(url)
+    }
+  }
+
   // --- Determine subdomain type ---
   let subdomainType: 'root' | 'admin' | 'district' = 'root'
   let districtSlug: string | null = null

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { MAINTENANCE_COOKIE_NAME } from '@/lib/maintenance'
 
 const ROOT_DOMAINS = [
   'stratadash.org',
@@ -32,12 +33,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.next()
   }
 
-  // --- Maintenance gate ---
-  // When MAINTENANCE_MODE=true, rewrite every page request to /maintenance
-  // unless the request carries a valid bypass cookie or targets the bypass route.
+  // Maintenance gate runs before subdomain routing so one flag covers every host.
+  // rewrite (not redirect) preserves the URL so 503 Service Unavailable accurately
+  // describes the response to bots, monitors, and CDN caches.
   if (process.env.MAINTENANCE_MODE === 'true') {
     const bypassKey = process.env.MAINTENANCE_BYPASS_KEY
-    const bypassCookie = request.cookies.get('maintenance_bypass')?.value
+    const bypassCookie = request.cookies.get(MAINTENANCE_COOKIE_NAME)?.value
     const hasBypass = Boolean(bypassKey) && bypassCookie === bypassKey
 
     const isMaintenanceRoute =


### PR DESCRIPTION
## Summary

- Adds a production-only maintenance/holding page gated by `MAINTENANCE_MODE=true`. Middleware rewrites every page request to `/maintenance` with HTTP 503; API routes, `_next/*`, and static assets pass through.
- The gate runs **before** subdomain routing, so one env var covers `stratadash.org`, `*.stratadash.org`, and `admin.stratadash.org`.
- Operator bypass: `/maintenance-bypass?key=SECRET` sets an `httpOnly` cookie scoped to the registrable domain (`.stratadash.org`), so one visit unlocks every subdomain in that browser for 30 days. Localhost and `*.vercel.app` fall back to host-only scoping.
- Preview deploys and local dev are untouched — the env var is only set on Vercel's Production scope.
- Full operator playbook added at `docs/maintenance-mode.md` (enable/disable/bypass/local testing/rationale).

## Why

Lets me polish the new public page designs on production without clients viewing mid-change, while preview deploys stay fully accessible for review.

## Test plan

- [ ] Set `MAINTENANCE_MODE=true` + `MAINTENANCE_BYPASS_KEY=...` in `.env.local`, run `npm run dev`, confirm `localhost:5174` returns the maintenance page with status 503.
- [ ] Hit `/maintenance-bypass?key=WRONG` → 404.
- [ ] Hit `/maintenance-bypass?key=CORRECT` → 302 to `/`, cookie set, real site renders.
- [ ] Confirm `/api/*` routes still respond (not gated).
- [ ] In Vercel Preview (env var unset), confirm the site renders normally.
- [ ] After merge, set production env vars, redeploy, verify maintenance page on `www.stratadash.org` and a district subdomain in an incognito window.
- [ ] Verify bypass cookie set on one subdomain unlocks all `*.stratadash.org` subdomains in the same browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)